### PR TITLE
Improvement: Read commit hash from editor product version field

### DIFF
--- a/Editor/Editor.csproj
+++ b/Editor/Editor.csproj
@@ -22,6 +22,8 @@
         <PackageLicenseUrl>https://github.com/tixl3d/tixl?tab=MIT-1-ov-file#readme</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/tixl3d/tixl</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
+        <!-- Ensure there's a git commit hash in the version field for the about dialog -->
+        <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
 
         <!-- <Authors>TiXL</Authors>
     <Owners>TiXL</Owners>
@@ -94,10 +96,7 @@
     </ItemGroup>
 
     <Target Name="CopyDefaults" AfterTargets="AfterBuild">
-        <Copy SourceFiles="@(DefaultUserConfigs)"
-            SkipUnchangedFiles="true"
-            UseHardlinksIfPossible="true"
-            DestinationFiles="@(DefaultUserConfigs->'$(OutputPath)/.tixl/%(RecursiveDir)%(Filename)%(Extension)')" />
+        <Copy SourceFiles="@(DefaultUserConfigs)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true" DestinationFiles="@(DefaultUserConfigs->'$(OutputPath)/.tixl/%(RecursiveDir)%(Filename)%(Extension)')" />
     </Target>
     <!-- ==========================//================================ -->
 
@@ -108,10 +107,7 @@
     </ItemGroup>
 
     <Target Name="CopyResources" AfterTargets="AfterBuild">
-        <Copy SourceFiles="@(Resources)"
-            SkipUnchangedFiles="true"
-            UseHardlinksIfPossible="true"
-            DestinationFiles="@(Resources->'$(OutputPath)/Resources/%(RecursiveDir)%(Filename)%(Extension)')" />
+        <Copy SourceFiles="@(Resources)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true" DestinationFiles="@(Resources->'$(OutputPath)/Resources/%(RecursiveDir)%(Filename)%(Extension)')" />
     </Target>
     <!-- ===========================//=============================== -->
 
@@ -132,10 +128,7 @@
         <Player Include="../Player/$(RelativeBuildFolder)/**/*" Visible="false" />
     </ItemGroup>
     <Target Name="CopyPlayer" AfterTargets="AfterBuild">
-        <Copy SourceFiles="@(Player)"
-            SkipUnchangedFiles="true"
-            UseHardlinksIfPossible="true"
-            DestinationFiles="@(Player->'$(OutputPath)/Player/%(RecursiveDir)%(Filename)%(Extension)')" />
+        <Copy SourceFiles="@(Player)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true" DestinationFiles="@(Player->'$(OutputPath)/Player/%(RecursiveDir)%(Filename)%(Extension)')" />
     </Target>
     <!-- =========================//=============================== -->
 
@@ -155,8 +148,7 @@
             <!-- This is a list of all the built-in operator projects. 'Include' refers to project
             directory, 'SubFolder' to export subfolder -->
             <Lib Include="$(Ops)/lib/$(RelativeBuildFolder)/**" SubFolder="lib" />
-            <TypeOperators Include="$(Ops)/TypeOperators/$(RelativeBuildFolder)/**"
-                SubFolder="TypeOperators" />
+            <TypeOperators Include="$(Ops)/TypeOperators/$(RelativeBuildFolder)/**" SubFolder="TypeOperators" />
             <LibEditor Include="$(Ops)/LibEditor/$(RelativeBuildFolder)/**" SubFolder="LibEditor" />
             <Examples Include="$(Ops)/examples/$(RelativeBuildFolder)/**" SubFolder="examples" />
             <Unsplash Include="$(Ops)/unsplash/$(RelativeBuildFolder)/**" SubFolder="unsplash" />
@@ -165,11 +157,7 @@
         </ItemGroup>
 
         <!-- Copy Dlls and symbols using the items and subfolders defined above -->
-        <Copy
-            SourceFiles="@(Lib);@(TypeOperators);@(LibEditor);@(Examples);@(Unsplash);@(Ndi);@(pixtur)"
-            DestinationFolder="$(ExportFolder)/%(SubFolder)/%(RecursiveDir)"
-            SkipUnchangedFiles="true"
-            UseHardlinksIfPossible="true" />
+        <Copy SourceFiles="@(Lib);@(TypeOperators);@(LibEditor);@(Examples);@(Unsplash);@(Ndi);@(pixtur)" DestinationFolder="$(ExportFolder)/%(SubFolder)/%(RecursiveDir)" SkipUnchangedFiles="true" UseHardlinksIfPossible="true" />
     </Target>
     <!-- ==================================//====================================== -->
 

--- a/Editor/Gui/Dialog/AboutDialog.cs
+++ b/Editor/Gui/Dialog/AboutDialog.cs
@@ -14,6 +14,7 @@ using SharpDX.Direct3D11;
 using T3.Core.Resource;
 using T3.Core.Animation;
 using System.Media;
+using System.Reflection;
 
 
 namespace T3.Editor.Gui.Dialog;
@@ -126,18 +127,14 @@ internal sealed class AboutDialog : ModalDialog
     {
         try
         {
-            using var process = new Process();
-            process.StartInfo.FileName = "git";
-            process.StartInfo.Arguments = "rev-parse --short HEAD";
-            process.StartInfo.UseShellExecute = false;
-            process.StartInfo.RedirectStandardOutput = true;
-            process.StartInfo.CreateNoWindow = true;
+            var assemblyLocation = Assembly.GetEntryAssembly()!.Location;
+            var productVersion = FileVersionInfo.GetVersionInfo(assemblyLocation)?.ProductVersion;
 
-            process.Start();
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExit();
+            if (productVersion is null || !productVersion.Contains("+"))
+                return "Unknown";
 
-            return string.IsNullOrEmpty(output) ? "Unknown" : output;
+            var commitHash = productVersion.Split("+")[1];
+            return commitHash.Substring(0, 8);
         }
         catch (Exception)
         {


### PR DESCRIPTION
Removes git dependency on running system.

The original would've had an undefined behavior when running on a system without the git client installed or if the executable had been moved outside the git repository tree.

Visually it is identical to the original.

![image](https://github.com/user-attachments/assets/f54ed04b-1f6d-406e-a9ed-f5cae689c71c)
