### PR TITLE
Improvement: chagned behavior of BYPASS button

### DIFF
--- a/Editor/Gui/Styling/CustomComponents.cs
+++ b/Editor/Gui/Styling/CustomComponents.cs
@@ -524,7 +524,7 @@ internal static class CustomComponents
 
     public static void TooltipForLastItem(Color color, string message, string additionalNotes = null, bool useHoverDelay = true)
     {
-        if (!ImGui.IsItemHovered())
+        if (!ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenDisabled))
             return;
 
         FrameStats.Current.SomethingWithTooltipHovered = true;

--- a/Editor/Gui/Windows/ParameterWindow.cs
+++ b/Editor/Gui/Windows/ParameterWindow.cs
@@ -485,10 +485,24 @@ internal sealed class ParameterWindow : Window
                 }
                 else
                 {
+                    var bypassable = symbolChildUi.SymbolChild.IsBypassable();
+
                     ImGui.PushStyleColor(ImGuiCol.Text, UiColors.TextMuted.Rgba);
+
+                    if (!bypassable)
+                    {
+                        ImGui.BeginDisabled();
+                    }
+
                     if (ImGui.Button("BYPASS", new Vector2(90, 0)))
                     {
                         UndoRedoStack.AddAndExecute(new ChangeInstanceBypassedCommand(symbolChildUi.SymbolChild, true));
+                    }
+
+                    if (!bypassable)
+                    { 
+                        CustomComponents.TooltipForLastItem("This operator cannot be bypassed");
+                        ImGui.EndDisabled();
                     }
 
                     ImGui.PopStyleColor();

--- a/Editor/TODO.md
+++ b/Editor/TODO.md
@@ -1,4 +1,4 @@
-﻿## Important issues
+## Important issues
 
 - [x] Fix camera handling
 - [x] Default gradients are not loaded?
@@ -12,7 +12,7 @@
 - [x] Picking video files from resource does not work.
 
 - [ ] Publish as input does not create connection
-- [ ] In Parameter window bypassable button should be disabled if not available
+- [x] In Parameter window bypassable button should be disabled if not available
 - [x] Prevent Keyboard Camera interaction while input field is active 
 
 ## Project handling


### PR DESCRIPTION
The button is grayed out when an operator cannot be bypassed. A tooltip is shown a when hovered to inform the user it isn't possible.

Screenshots of:
- normal bypassable operator
![TiXL_7cpijkP6XZ](https://github.com/user-attachments/assets/ed783467-44e0-4241-a4bb-8b590bf14c8c)

- non bypassable operator
![TiXL_9e4nU3F5XN](https://github.com/user-attachments/assets/f6bf73ca-3573-4d43-9ab3-7e0b8973a227)
