### PR TITLE
Fix ScreenShots feature

### DIFF
--- a/Editor/Gui/AutoBackup/AutoBackup.cs
+++ b/Editor/Gui/AutoBackup/AutoBackup.cs
@@ -54,7 +54,7 @@ internal static class AutoBackup
 
         var zipFilePath = Path.Join(BackupDirectory, $"#{index:D5}-{DateTime.Now:yyyy_MM_dd-HH_mm_ss_fff}.zip");
 
-        var excludedDirs = new[] { "bin", "obj", ".git", "Render", "ImageSequence" };
+        var excludedDirs = new[] { "bin", "obj", ".git", "Render", "ImageSequence", "Screenshots" };
         try
         {
             using var archive = ZipFile.Open(zipFilePath, ZipArchiveMode.Create);

--- a/Editor/Gui/Windows/Output/OutputWindow.cs
+++ b/Editor/Gui/Windows/Output/OutputWindow.cs
@@ -1,8 +1,7 @@
-﻿using System.IO;
 using ImGuiNET;
+using System.IO;
 using T3.Core.DataTypes;
 using T3.Core.Operator;
-using T3.Core.Operator.Slots;
 using T3.Editor.Gui.Interaction;
 using T3.Editor.Gui.OutputUi;
 using T3.Editor.Gui.Styling;
@@ -10,6 +9,7 @@ using T3.Editor.Gui.UiHelpers;
 using T3.Editor.Gui.Windows.Layouts;
 using T3.Editor.Gui.Windows.RenderExport;
 using T3.Editor.UiModel;
+using T3.Editor.UiModel.ProjectHandling;
 using Texture2D = T3.Core.DataTypes.Texture2D;
 using Vector2 = System.Numerics.Vector2;
 
@@ -186,14 +186,17 @@ internal sealed class OutputWindow : Window
         CustomComponents.TooltipForLastItem("Adjust background color of view");
         ImGui.PopStyleColor();
 
-        var texture = GetCurrentTexture();
-        if (texture != null)
+        var texture = GetCurrentTexture();  
+        // if (texture != null)
+        if (drawnType == typeof(Texture2D) || drawnType == typeof(Command))
         {
             ImGui.SameLine();
 
             if (CustomComponents.IconButton(Icon.Snapshot, new Vector2(ImGui.GetFrameHeight(), ImGui.GetFrameHeight())))
             {
-                const string folder = @"Screenshots/";
+                var project = ProjectView.Focused?.OpenedProject;
+                var projectFolder = project.Package.Folder;
+                var folder = Path.Combine(projectFolder, "Screenshots");
                 if (!Directory.Exists(folder))
                 {
                     Directory.CreateDirectory(folder);


### PR DESCRIPTION
## Problem: 
No matter the selected operator `GetCurrentTexture()`  is never null so the Screenshot button is always visible. 

While in Debug mode, clicking the Screenshot button was creating a Screenshot folder in _Editor\bin\Debug\net9.0-windows_

If a _Command_ or a _Texture2D_ operator is selected we get a png file with the content of the Output View.

If an other kinf of operator is selected we get a png file with the last render (from a Command or Texture2D) of the Output View. 

## Solution:
Same logic as for the _"Start Render"_ button in the Render To File window

But here we allow to save screenshots for _Texture2D_ and _Command_ operators.

If it doesn't exist a _Screenshots_  folder is created in the opened project's folder and the png image is written inside.  

I also added the Screenshots folder to the list of excluded directories in AutoBackup.cs 




