### PR TITLE
Add dot product and cross product ops

### DIFF
--- a/Operators/Lib/numbers/vec2/DotVec2.cs
+++ b/Operators/Lib/numbers/vec2/DotVec2.cs
@@ -1,0 +1,24 @@
+namespace Lib.numbers.vec2;
+
+[Guid("0db4fd9b-7996-47e1-a4cc-debfd04a18f4")]
+internal sealed class DotVec2 : Instance<DotVec2>
+{
+    [Input(Guid = "bac6bef8-1bf3-4f74-9198-c06dec48610c")]
+    public readonly InputSlot<Vector2> Input1 = new();
+    
+    [Input(Guid = "3f28ec3a-e7ab-41f5-95d4-e3cc5b6357f9")]
+    public readonly InputSlot<Vector2> Input2 = new();
+
+    [Output(Guid = "18591f1a-87f0-49fc-8608-b30b98364b67")]
+    public readonly Slot<float> Result = new();
+
+    public DotVec2()
+    {
+        Result.UpdateAction += Update;
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        Result.Value = Vector2.Dot(Input1.GetValue(context), Input2.GetValue(context));
+    }
+}

--- a/Operators/Lib/numbers/vec2/DotVec2.t3
+++ b/Operators/Lib/numbers/vec2/DotVec2.t3
@@ -1,0 +1,21 @@
+{
+  "Id": "0db4fd9b-7996-47e1-a4cc-debfd04a18f4"/*DotVec2*/,
+  "Inputs": [
+    {
+      "Id": "3f28ec3a-e7ab-41f5-95d4-e3cc5b6357f9"/*Input2*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0
+      }
+    },
+    {
+      "Id": "bac6bef8-1bf3-4f74-9198-c06dec48610c"/*Input1*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0
+      }
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/numbers/vec2/DotVec2.t3ui
+++ b/Operators/Lib/numbers/vec2/DotVec2.t3ui
@@ -1,0 +1,30 @@
+{
+  "Id": "0db4fd9b-7996-47e1-a4cc-debfd04a18f4"/*DotVec2*/,
+  "Description": "Applies a dot product to two Vec2's",
+  "InputUis": [
+    {
+      "InputId": "3f28ec3a-e7ab-41f5-95d4-e3cc5b6357f9"/*Input2*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      }
+    },
+    {
+      "InputId": "bac6bef8-1bf3-4f74-9198-c06dec48610c"/*Input1*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      }
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "18591f1a-87f0-49fc-8608-b30b98364b67"/*Result*/,
+      "Position": {
+        "X": 100.0,
+        "Y": 0.0
+      }
+    }
+  ]
+}

--- a/Operators/Lib/numbers/vec3/CrossVec3.cs
+++ b/Operators/Lib/numbers/vec3/CrossVec3.cs
@@ -1,0 +1,29 @@
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+using System.Runtime.InteropServices;
+
+namespace Lib.numbers.vec3;
+
+[Guid("6cc830f0-cbc5-430d-9f32-1eab47b44693")]
+internal sealed class CrossVec3 : Instance<CrossVec3>
+{
+    public CrossVec3()
+    {
+        Result.UpdateAction += Update;
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        Result.Value = Vector3.Cross(Input1.GetValue(context), Input2.GetValue(context));
+    }
+    
+    [Input(Guid = "c88f66a4-8702-48ed-9693-29b3eac044f9")]
+    public readonly InputSlot<System.Numerics.Vector3> Input1 = new InputSlot<System.Numerics.Vector3>();
+
+    [Input(Guid = "5d81821a-19d1-4961-b895-09c25f3f6afe")]
+    public readonly InputSlot<System.Numerics.Vector3> Input2 = new InputSlot<System.Numerics.Vector3>();
+
+    [Output(Guid = "b5f83b5e-ed8c-47c4-bff2-c6f24651223d")]
+    public readonly Slot<System.Numerics.Vector3> Result = new Slot<System.Numerics.Vector3>();
+}

--- a/Operators/Lib/numbers/vec3/CrossVec3.t3
+++ b/Operators/Lib/numbers/vec3/CrossVec3.t3
@@ -1,0 +1,23 @@
+{
+  "Id": "6cc830f0-cbc5-430d-9f32-1eab47b44693"/*CrossVec3*/,
+  "Inputs": [
+    {
+      "Id": "5d81821a-19d1-4961-b895-09c25f3f6afe"/*Input2*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    },
+    {
+      "Id": "c88f66a4-8702-48ed-9693-29b3eac044f9"/*Input1*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/numbers/vec3/CrossVec3.t3ui
+++ b/Operators/Lib/numbers/vec3/CrossVec3.t3ui
@@ -1,0 +1,30 @@
+{
+  "Id": "6cc830f0-cbc5-430d-9f32-1eab47b44693"/*CrossVec3*/,
+  "Description": "Applies a cross product to two Vec3's",
+  "InputUis": [
+    {
+      "InputId": "5d81821a-19d1-4961-b895-09c25f3f6afe"/*Input2*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      }
+    },
+    {
+      "InputId": "c88f66a4-8702-48ed-9693-29b3eac044f9"/*Input1*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      }
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "b5f83b5e-ed8c-47c4-bff2-c6f24651223d"/*Result*/,
+      "Position": {
+        "X": 100.0,
+        "Y": 0.0
+      }
+    }
+  ]
+}

--- a/Operators/Lib/numbers/vec3/DotVec3.cs
+++ b/Operators/Lib/numbers/vec3/DotVec3.cs
@@ -1,0 +1,24 @@
+namespace Lib.numbers.vec3;
+
+[Guid("57e2c1de-95e7-4fd7-bbfb-2349e1fb17b4")]
+internal sealed class DotVec3 : Instance<DotVec3>
+{
+    [Input(Guid = "6e543f12-1849-4a75-93e3-052eae0d551d")]
+    public readonly InputSlot<Vector3> Input1 = new();
+
+    [Input(Guid = "21ae0f87-f8b9-427b-81c3-6f9a5f503b58")]
+    public readonly InputSlot<Vector3> Input2 = new();
+
+    [Output(Guid = "b1758ea3-cb8c-42dc-b229-8e1b59ac2033")]
+    public readonly Slot<float> Result = new();
+
+    public DotVec3()
+    {
+        Result.UpdateAction += Update;
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        Result.Value = Vector3.Dot(Input1.GetValue(context), Input2.GetValue(context));
+    }
+}

--- a/Operators/Lib/numbers/vec3/DotVec3.t3
+++ b/Operators/Lib/numbers/vec3/DotVec3.t3
@@ -1,0 +1,23 @@
+{
+  "Id": "57e2c1de-95e7-4fd7-bbfb-2349e1fb17b4"/*DotVec3*/,
+  "Inputs": [
+    {
+      "Id": "21ae0f87-f8b9-427b-81c3-6f9a5f503b58"/*Input2*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    },
+    {
+      "Id": "6e543f12-1849-4a75-93e3-052eae0d551d"/*Input1*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/numbers/vec3/DotVec3.t3ui
+++ b/Operators/Lib/numbers/vec3/DotVec3.t3ui
@@ -1,0 +1,30 @@
+{
+  "Id": "57e2c1de-95e7-4fd7-bbfb-2349e1fb17b4"/*DotVec3*/,
+  "Description": "Applies a dot product to two Vec3's",
+  "InputUis": [
+    {
+      "InputId": "21ae0f87-f8b9-427b-81c3-6f9a5f503b58"/*Input2*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      }
+    },
+    {
+      "InputId": "6e543f12-1849-4a75-93e3-052eae0d551d"/*Input1*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      }
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "b1758ea3-cb8c-42dc-b229-8e1b59ac2033"/*Result*/,
+      "Position": {
+        "X": 100.0,
+        "Y": 0.0
+      }
+    }
+  ]
+}

--- a/Operators/Lib/numbers/vec4/DotVec4.cs
+++ b/Operators/Lib/numbers/vec4/DotVec4.cs
@@ -1,0 +1,24 @@
+﻿namespace Lib.numbers.vec4;
+
+[Guid("0acc2bdb-f8e6-4280-aa89-702f1cb7722b")]
+internal sealed class DotVec4 : Instance<DotVec4>
+{
+    [Input(Guid = "cf1ec3c4-8b42-4c12-ba10-ca1db88c1a97")]
+    public readonly InputSlot<Vector4> Input1 = new();
+    
+    [Input(Guid = "063073d6-7ef7-4409-99b7-68f5a40a0d83")]
+    public readonly InputSlot<Vector4> Input2 = new();
+
+    [Output(Guid = "498882f3-3e13-43dd-9758-962c3f3d1408")]
+    public readonly Slot<float> Result = new();
+
+    public DotVec4()
+    {
+        Result.UpdateAction += Update;
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        Result.Value = Vector4.Dot(Input1.GetValue(context), Input2.GetValue(context));
+    }
+}

--- a/Operators/Lib/numbers/vec4/DotVec4.t3
+++ b/Operators/Lib/numbers/vec4/DotVec4.t3
@@ -1,0 +1,25 @@
+{
+  "Id": "0acc2bdb-f8e6-4280-aa89-702f1cb7722b"/*DotVec4*/,
+  "Inputs": [
+    {
+      "Id": "063073d6-7ef7-4409-99b7-68f5a40a0d83"/*Input2*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0,
+        "W": 0.0
+      }
+    },
+    {
+      "Id": "cf1ec3c4-8b42-4c12-ba10-ca1db88c1a97"/*Input1*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0,
+        "W": 0.0
+      }
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/numbers/vec4/DotVec4.t3ui
+++ b/Operators/Lib/numbers/vec4/DotVec4.t3ui
@@ -1,0 +1,30 @@
+{
+  "Id": "0acc2bdb-f8e6-4280-aa89-702f1cb7722b"/*DotVec4*/,
+  "Description": "Applies a dot product to two Vec4's",
+  "InputUis": [
+    {
+      "InputId": "063073d6-7ef7-4409-99b7-68f5a40a0d83"/*Input2*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      }
+    },
+    {
+      "InputId": "cf1ec3c4-8b42-4c12-ba10-ca1db88c1a97"/*Input1*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      }
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "498882f3-3e13-43dd-9758-962c3f3d1408"/*Result*/,
+      "Position": {
+        "X": 100.0,
+        "Y": 0.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Somehow, there are no dot product or cross products ops. This PR adds those.

This PR adds 4 new ops:
- `DotVec2`
- `DotVec3`
- `DotVec4`
- `CrossVec3`

![image](https://github.com/user-attachments/assets/f4038c39-0eb6-4a8e-936c-c0d9b5f0aa9d)

These are quite essential when doing 3D graphics.