### PR TITLE
Arc Connection Segments Setting

### DIFF
--- a/Editor/Gui/MagGraph/Ui/MagGraphCanvas.DrawNode.cs
+++ b/Editor/Gui/MagGraph/Ui/MagGraphCanvas.DrawNode.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using ImGuiNET;
 using T3.Core.DataTypes.Vector;
 using T3.Core.Model;
@@ -142,7 +142,7 @@ internal sealed partial class MagGraphCanvas
         if (isSelected)
         {
             drawList.AddRect(pMinVisible, pMaxVisible, UiColors.ForegroundFull.Fade(_context.GraphOpacity),
-                             CanvasScale < 0.5 ? 0 : 6 * CanvasScale,
+                             CanvasScale < 0.5 ? 0 : 5 * CanvasScale,
                              imDrawFlags);
         }
         
@@ -151,7 +151,7 @@ internal sealed partial class MagGraphCanvas
         if (isHighlighted)
         {
             drawList.AddRect(pMinVisible, pMaxVisible, UiColors.ForegroundFull.Fade(Blink),
-                             CanvasScale < 0.5 ? 0 : 6 * CanvasScale,
+                             CanvasScale < 0.5 ? 0 : 5 * CanvasScale,
                              imDrawFlags);
         }
 
@@ -316,7 +316,7 @@ internal sealed partial class MagGraphCanvas
                     }
 
                     // Draw selection outline...
-                    drawList.AddRect(pMinVisible, pMaxVisible, UiColors.ForegroundFull.Fade(_hoverPickingProgress * 0.4f), 6 * CanvasScale, imDrawFlags);
+                    drawList.AddRect(pMinVisible, pMaxVisible, UiColors.ForegroundFull.Fade(_hoverPickingProgress * 0.4f), CanvasScale < 0.5 ? 0 : 5 * CanvasScale, imDrawFlags);
 
                     ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(8, 8));
                     ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 3);

--- a/Editor/Gui/UiHelpers/ArcConnection.cs
+++ b/Editor/Gui/UiHelpers/ArcConnection.cs
@@ -258,7 +258,7 @@ internal static class GraphConnectionDrawer
     private static int ComputerSegmentCount(float arcLengthRad, float canvasScale)
     {
         var circleResolution = (int) canvasScale.RemapAndClamp(0.2f, 1.5f, 6, 15);
-        return (int)(arcLengthRad * circleResolution).Clamp(1,100);
+        return (int)(arcLengthRad * circleResolution).Clamp(1, UserSettings.Config.MaxSegmentCount);
     }
     
     private static float ComputeInnerTangentAngle(Vector2 centerA, float radiusA, Vector2 centerB, float radiusB, bool flipped = false)

--- a/Editor/Gui/UiHelpers/UserSettings.cs
+++ b/Editor/Gui/UiHelpers/UserSettings.cs
@@ -81,6 +81,7 @@ public sealed class UserSettings : Settings<UserSettings.ConfigData>
         public int ValueEditSmoothing = 0;
         public float ScrollSmoothing = 0.075f;
         public float MaxCurveRadius = 350;
+        public int MaxSegmentCount = 32;
 
         public float ClickThreshold = 5; // Increase for high-res display and pen tablets
         public bool AdjustCameraSpeedWithMouseWheel = false;

--- a/Editor/Gui/Windows/SettingsWindow.cs
+++ b/Editor/Gui/Windows/SettingsWindow.cs
@@ -1,4 +1,4 @@
-﻿using System.IO;
+using System.IO;
 using ImGuiNET;
 using Operators.Utils;
 using T3.Core.IO;
@@ -101,6 +101,9 @@ internal sealed class SettingsWindow : Window
                                                        ref UserSettings.Config.MaxCurveRadius,
                                                        0.0f, 1000f, 1f, true, "Controls the roundness of curve lines",
                                                        UserSettings.Defaults.MaxCurveRadius);
+                        changed |= FormInputs.AddInt("Connection segments",
+                                                       ref UserSettings.Config.MaxSegmentCount, 1, 100, 1f,
+                                                       "Controls the number of segments used to draw connections between operators.", UserSettings.Defaults.MaxSegmentCount);
                     }
                     else
                     {


### PR DESCRIPTION
Adds a new Magnetic Graph setting to let user change the segment amount of the arc connection. 
![image](https://github.com/user-attachments/assets/d92bae3b-61e8-4738-9c27-b5462cef2245)

Also a small fix to adjust the node selection line rounded corner match to the node.
![image](https://github.com/user-attachments/assets/8c8898b5-36f4-416c-af9c-68da254de1c1)
