### PR TITLE
Add "Save and Exit" button to Exit Dialog

### DIFF
--- a/Editor/Gui/Dialog/ExitDialog.cs
+++ b/Editor/Gui/Dialog/ExitDialog.cs
@@ -11,6 +11,8 @@ namespace T3.Editor.Gui.Dialog;
 
 internal sealed class ExitDialog : ModalDialog
 {
+    private bool _exitAfterSave = false;
+
     internal void Draw()
     {
         DialogSize = new Vector2(330, 200);
@@ -23,6 +25,19 @@ internal sealed class ExitDialog : ModalDialog
             if (changeCount > 0)
             {
                 ImGui.Text($"Your have {changeCount} unsaved changes.");
+                if (ImGui.Button("Save and Exit") && !T3Ui.IsCurrentlySaving)
+                {
+                    _exitAfterSave = true;
+                    T3Ui.SaveInBackground(saveAll: false);
+                }
+              
+            }
+            // Check if we should exit after save completed
+            if (_exitAfterSave && !T3Ui.IsCurrentlySaving && GetChangedSymbolCount() == 0)
+            {
+                _exitAfterSave = false;
+                Log.Debug("Exiting after saving");
+                EditorUi.Instance.ExitApplication();
             }
 
             FormInputs.AddVerticalSpace();
@@ -33,12 +48,12 @@ internal sealed class ExitDialog : ModalDialog
             var buttonSize = new Vector2(100f, 40f);
             var size = ImGui.GetContentRegionAvail();
             var spacing = (size.X - 200f);
-            
+
             if (ImGui.Button("Cancel", buttonSize))
             {
                 ImGui.CloseCurrentPopup();
             }
-                        
+
             ImGui.SameLine(0, spacing);
 
             ImGui.PushFont(Fonts.FontBold);

--- a/Editor/Gui/Dialog/ExitDialog.cs
+++ b/Editor/Gui/Dialog/ExitDialog.cs
@@ -15,22 +15,47 @@ internal sealed class ExitDialog : ModalDialog
 
     internal void Draw()
     {
-        DialogSize = new Vector2(330, 200);
+        DialogSize = new Vector2(420, 200);
 
         if (BeginDialog(string.Empty))
         {
             FormInputs.AddSectionHeader("Are you leaving?");
 
+            ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 5.0f);
+            ImGui.PushStyleColor(ImGuiCol.Button, UiColors.BackgroundButton.Rgba);
+            ImGui.PushStyleColor(ImGuiCol.ButtonHovered, UiColors.BackgroundActive.Rgba);
+            var buttonSize = new Vector2(110f, 40f) * T3Ui.UiScaleFactor;
+            var size = ImGui.GetContentRegionAvail();
+            float spacing;
             var changeCount = GetChangedSymbolCount();
+
             if (changeCount > 0)
             {
-                ImGui.Text($"Your have {changeCount} unsaved changes.");
-                if (ImGui.Button("Save and Exit") && !T3Ui.IsCurrentlySaving)
+                spacing = (size.X - buttonSize.X * 3)/2;
+            }
+            else
+            {
+                spacing = (size.X - buttonSize.X * 2);
+            }
+
+            FormInputs.AddVerticalSpace(2);
+
+            if (ImGui.Button("Cancel", buttonSize))
+            {
+                ImGui.CloseCurrentPopup();
+            }
+
+            ImGui.SameLine(0, spacing);
+
+            if (changeCount > 0)
+            {
+                
+                if (ImGui.Button("Save and Exit", buttonSize) && !T3Ui.IsCurrentlySaving)
                 {
                     _exitAfterSave = true;
                     T3Ui.SaveInBackground(saveAll: false);
                 }
-              
+                ImGui.SameLine(0, spacing);
             }
             // Check if we should exit after save completed
             if (_exitAfterSave && !T3Ui.IsCurrentlySaving && GetChangedSymbolCount() == 0)
@@ -40,27 +65,16 @@ internal sealed class ExitDialog : ModalDialog
                 EditorUi.Instance.ExitApplication();
             }
 
-            FormInputs.AddVerticalSpace();
-            ImGui.PushStyleVar(ImGuiStyleVar.FrameRounding, 5.0f);
-            ImGui.PushStyleColor(ImGuiCol.Button, UiColors.BackgroundButton.Rgba);
-            ImGui.PushStyleColor(ImGuiCol.ButtonHovered, UiColors.BackgroundActive.Rgba);
-
-            var buttonSize = new Vector2(100f, 40f);
-            var size = ImGui.GetContentRegionAvail();
-            var spacing = (size.X - 200f);
-
-            if (ImGui.Button("Cancel", buttonSize))
-            {
-                ImGui.CloseCurrentPopup();
-            }
-
-            ImGui.SameLine(0, spacing);
-
             ImGui.PushFont(Fonts.FontBold);
             if (ImGui.Button("Exit", buttonSize))
             {
                 Log.Debug("Shutting down");
                 EditorUi.Instance.ExitApplication();
+            }
+            FormInputs.AddVerticalSpace(2);
+            if (changeCount > 0)
+            {
+                ImGui.Text($"Your have {changeCount} unsaved changes.");
             }
 
             ImGui.PopFont();


### PR DESCRIPTION
"Save and Exit" button appears only if there is unsaved changes. 
Buttons are working properly with `T3Ui.UiScaleFactor` 

![image](https://github.com/user-attachments/assets/c2fe383d-f916-4dea-9b7c-4e815089d419)
