### PR TITLE
DrawMesh : Fix Alpha and Add Flat Shading

### DIFF
--- a/Operators/Lib/Resources/3d/mesh/mesh-Draw.hlsl
+++ b/Operators/Lib/Resources/3d/mesh/mesh-Draw.hlsl
@@ -145,12 +145,6 @@ inline float4 GetField(float4 p)
     float4 f = 1;
     /*{FIELD_CALL}*/
 
-#ifndef USE_WORLDSPACE
-    float originalAlpha = f.w;
-    float uniformScale = length(ObjectToWorld[0].xyz);
-    f.w *= uniformScale;
-    f.w = originalAlpha; // Restore original alpha
-#endif
     return f;
 }
 

--- a/Operators/Lib/Resources/3d/mesh/mesh-Draw.hlsl
+++ b/Operators/Lib/Resources/3d/mesh/mesh-Draw.hlsl
@@ -21,7 +21,8 @@ cbuffer Params : register(b1)
 {
     float4 Color;
     float AlphaCutOff;
-    float Debug;
+    //float Debug;
+    float UseFlatShading;
 };
 
 cbuffer FogParams : register(b2)
@@ -145,8 +146,10 @@ inline float4 GetField(float4 p)
     /*{FIELD_CALL}*/
 
 #ifndef USE_WORLDSPACE
+    float originalAlpha = f.w;
     float uniformScale = length(ObjectToWorld[0].xyz);
     f.w *= uniformScale;
+    f.w = originalAlpha; // Restore original alpha
 #endif
     return f;
 }
@@ -177,10 +180,34 @@ float4 psMain(psInput pin) : SV_TARGET
     float3 Lo = normalize(eyePosition.xyz - pin.worldPosition);
 
     // Get current fragment's normal and transform to world space.
-    float4 normalMap = NormalMap.Sample(TexSampler, pin.texCoord);
-
-    float3 N = normalize(2.0 * normalMap.rgb - 1.0);
-    N = normalize(mul(N, pin.tbnToWorld));
+       float3 N;
+    if (UseFlatShading > 0.5)
+    {
+        // Flat shading: calculate geometric normal from world position derivatives
+        float3 dpdx = ddx(pin.worldPosition);
+        float3 dpdy = ddy(pin.worldPosition);
+        float3 geometricNormal = normalize(cross(dpdy, dpdx));
+        
+        // Apply normal map details on top of flat normal
+        float4 normalMap = NormalMap.Sample(TexSampler, pin.texCoord);
+        float3 normalDetail = normalize(2.0 * normalMap.rgb - 1.0);
+        
+        // Create TBN basis using geometric normal and derivatives
+        float3 T = normalize(dpdx);
+        float3 B = normalize(cross(geometricNormal, T));
+        T = cross(B, geometricNormal); // Reorthogonalize
+        float3x3 flatTBN = float3x3(T, B, geometricNormal);
+        
+        // Apply normal map in flat shading tangent space
+        N = normalize(mul(normalDetail, flatTBN));
+    }
+    else
+    {
+        // Standard shading: use interpolated normals with normal mapping
+        float4 normalMap = NormalMap.Sample(TexSampler, pin.texCoord);
+        N = normalize(2.0 * normalMap.rgb - 1.0);
+        N = normalize(mul(N, pin.tbnToWorld));
+    }
 
     // Angle between surface normal and outgoing light direction.
     frag.cosLo = abs(dot(N, Lo));

--- a/Operators/Lib/mesh/draw/DrawMesh.cs
+++ b/Operators/Lib/mesh/draw/DrawMesh.cs
@@ -76,6 +76,11 @@ internal sealed class DrawMesh : Instance<DrawMesh>, ICustomDropdownHolder, ICom
     private readonly List<PbrMaterial> _pbrMaterials = new(8);
     #endregion
         
+    private enum ShadingModes
+    {
+        Default = 0,
+        Flat = 1,
+    }
 
     [Input(Guid = "97429e1f-3f30-4789-89a6-8e930e356ee6")]
     public readonly InputSlot<MeshBuffers> Mesh = new InputSlot<MeshBuffers>();
@@ -95,8 +100,8 @@ internal sealed class DrawMesh : Instance<DrawMesh>, ICustomDropdownHolder, ICom
     [Input(Guid = "9e957f4a-6502-4905-8d97-331f8b54097c")]
     public readonly InputSlot<CullMode> Culling = new InputSlot<CullMode>();
 
-    [Input(Guid = "05e0b0e3-6e79-48bd-a356-3dcb65c9040f")]
-    public readonly InputSlot<bool> FlatShading = new InputSlot<bool>();
+    [Input(Guid = "05e0b0e3-6e79-48bd-a356-3dcb65c9040f", MappedType = typeof(ShadingModes))]
+    public readonly InputSlot<int> Shading = new();
 
     [Input(Guid = "b50b3fc7-35e1-421d-be0a-b3008a54c33c")]
     public readonly InputSlot<bool> EnableZTest = new InputSlot<bool>();

--- a/Operators/Lib/mesh/draw/DrawMesh.cs
+++ b/Operators/Lib/mesh/draw/DrawMesh.cs
@@ -95,6 +95,9 @@ internal sealed class DrawMesh : Instance<DrawMesh>, ICustomDropdownHolder, ICom
     [Input(Guid = "9e957f4a-6502-4905-8d97-331f8b54097c")]
     public readonly InputSlot<CullMode> Culling = new InputSlot<CullMode>();
 
+    [Input(Guid = "05e0b0e3-6e79-48bd-a356-3dcb65c9040f")]
+    public readonly InputSlot<bool> FlatShading = new InputSlot<bool>();
+
     [Input(Guid = "b50b3fc7-35e1-421d-be0a-b3008a54c33c")]
     public readonly InputSlot<bool> EnableZTest = new InputSlot<bool>();
 
@@ -115,6 +118,4 @@ internal sealed class DrawMesh : Instance<DrawMesh>, ICustomDropdownHolder, ICom
 
         [Input(Guid = "96df9e72-189f-4efc-82a6-b2f482166e34")]
         public readonly InputSlot<string> ShaderDefines = new InputSlot<string>();
-
-
 }

--- a/Operators/Lib/mesh/draw/DrawMesh.t3
+++ b/Operators/Lib/mesh/draw/DrawMesh.t3
@@ -2,8 +2,8 @@
   "Id": "a3c5471e-079b-4d4b-886a-ec02d6428ff6"/*DrawMesh*/,
   "Inputs": [
     {
-      "Id": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f"/*FlatShading*/,
-      "DefaultValue": false
+      "Id": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f"/*Shading*/,
+      "DefaultValue": 0
     },
     {
       "Id": "155c2396-0e05-4437-8171-288048b1158a"/*Filter*/,
@@ -64,6 +64,12 @@
     }
   ],
   "Children": [
+    {
+      "Id": "01992f57-197e-459f-938f-159805816b8d"/*IntToFloat*/,
+      "SymbolId": "17db8a36-079d-4c83-8a2a-7ea4c1aa49e6",
+      "InputValues": [],
+      "Outputs": []
+    },
     {
       "Id": "036bd517-a749-4fc7-bdf1-3845d2e51166"/*linearSampler*/,
       "SymbolId": "9515d59d-0bd5-406b-96da-6a5f60215700",
@@ -133,12 +139,6 @@
     {
       "Id": "44cb1668-6160-42b6-a7fe-803922b5e272"/*InputAssemblerStage*/,
       "SymbolId": "9d1266c5-23db-439f-a475-8000fdd1c318",
-      "InputValues": [],
-      "Outputs": []
-    },
-    {
-      "Id": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8"/*BoolToFloat*/,
-      "SymbolId": "9db2fcbf-54b9-4222-878b-80d1a0dc6edf",
       "InputValues": [],
       "Outputs": []
     },
@@ -419,6 +419,12 @@
     },
     {
       "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f",
+      "TargetParentOrChildId": "01992f57-197e-459f-938f-159805816b8d",
+      "TargetSlotId": "01809b63-4b4a-47be-9588-98d5998ddb0c"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "SourceSlotId": "d1db33ea-1739-4323-9105-7b236a0e240f",
       "TargetParentOrChildId": "036bd517-a749-4fc7-bdf1-3845d2e51166",
       "TargetSlotId": "e7c95fd5-14d1-434f-a140-f22ef69076ab"
@@ -488,12 +494,6 @@
       "SourceSlotId": "49b28dc3-fcd1-4067-bc83-e1cc848ae55c",
       "TargetParentOrChildId": "1ac59a27-5de5-43c3-a308-320cab00aa65",
       "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
-    },
-    {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f",
-      "TargetParentOrChildId": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8",
-      "TargetSlotId": "253b9ae4-fac5-4641-bf0c-d8614606a840"
     },
     {
       "SourceParentOrChildId": "151209ef-f52b-4c88-9d9c-5a8882fb0e1d",
@@ -742,8 +742,8 @@
       "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
     },
     {
-      "SourceParentOrChildId": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8",
-      "SourceSlotId": "f0321a54-e844-482f-a161-7f137abc54b0",
+      "SourceParentOrChildId": "01992f57-197e-459f-938f-159805816b8d",
+      "SourceSlotId": "db1073a1-b9d8-4d52-bc5c-7ae8c0ee1ac3",
       "TargetParentOrChildId": "e57d129b-4621-4971-ba62-7ab87cafadcb",
       "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
     },

--- a/Operators/Lib/mesh/draw/DrawMesh.t3
+++ b/Operators/Lib/mesh/draw/DrawMesh.t3
@@ -2,6 +2,10 @@
   "Id": "a3c5471e-079b-4d4b-886a-ec02d6428ff6"/*DrawMesh*/,
   "Inputs": [
     {
+      "Id": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f"/*FlatShading*/,
+      "DefaultValue": false
+    },
+    {
       "Id": "155c2396-0e05-4437-8171-288048b1158a"/*Filter*/,
       "DefaultValue": "MinMagMipLinear"
     },
@@ -129,6 +133,12 @@
     {
       "Id": "44cb1668-6160-42b6-a7fe-803922b5e272"/*InputAssemblerStage*/,
       "SymbolId": "9d1266c5-23db-439f-a475-8000fdd1c318",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8"/*BoolToFloat*/,
+      "SymbolId": "9db2fcbf-54b9-4222-878b-80d1a0dc6edf",
       "InputValues": [],
       "Outputs": []
     },
@@ -480,6 +490,12 @@
       "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
     },
     {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f",
+      "TargetParentOrChildId": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8",
+      "TargetSlotId": "253b9ae4-fac5-4641-bf0c-d8614606a840"
+    },
+    {
       "SourceParentOrChildId": "151209ef-f52b-4c88-9d9c-5a8882fb0e1d",
       "SourceSlotId": "a1ab0c16-ed15-4334-a529-10e3c217df1a",
       "TargetParentOrChildId": "56be1fd2-548c-4814-9e1b-5ab09f95cf1d",
@@ -722,6 +738,12 @@
     {
       "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "SourceSlotId": "4748d9ab-58a4-41d7-a2ee-6f7dfed86211",
+      "TargetParentOrChildId": "e57d129b-4621-4971-ba62-7ab87cafadcb",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8",
+      "SourceSlotId": "f0321a54-e844-482f-a161-7f137abc54b0",
       "TargetParentOrChildId": "e57d129b-4621-4971-ba62-7ab87cafadcb",
       "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
     },

--- a/Operators/Lib/mesh/draw/DrawMesh.t3ui
+++ b/Operators/Lib/mesh/draw/DrawMesh.t3ui
@@ -4,7 +4,7 @@
   "SymbolTags": "1",
   "InputUis": [
     {
-      "InputId": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f"/*FlatShading*/,
+      "InputId": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f"/*Shading*/,
       "Position": {
         "X": 1622.4233,
         "Y": 3720.1924
@@ -125,6 +125,13 @@
   ],
   "SymbolChildUis": [
     {
+      "ChildId": "01992f57-197e-459f-938f-159805816b8d"/*IntToFloat*/,
+      "Position": {
+        "X": 1885.1946,
+        "Y": 3769.764
+      }
+    },
+    {
       "ChildId": "036bd517-a749-4fc7-bdf1-3845d2e51166"/*linearSampler*/,
       "Position": {
         "X": 2221.8616,
@@ -193,13 +200,6 @@
       "Position": {
         "X": 2863.2698,
         "Y": 3271.7793
-      }
-    },
-    {
-      "ChildId": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8"/*BoolToFloat*/,
-      "Position": {
-        "X": 1791.5083,
-        "Y": 3720.9985
       }
     },
     {

--- a/Operators/Lib/mesh/draw/DrawMesh.t3ui
+++ b/Operators/Lib/mesh/draw/DrawMesh.t3ui
@@ -4,6 +4,14 @@
   "SymbolTags": "1",
   "InputUis": [
     {
+      "InputId": "05e0b0e3-6e79-48bd-a356-3dcb65c9040f"/*FlatShading*/,
+      "Position": {
+        "X": 1622.4233,
+        "Y": 3720.1924
+      },
+      "Description": "If enabled, the mesh is rendered with flat shading."
+    },
+    {
       "InputId": "155c2396-0e05-4437-8171-288048b1158a"/*Filter*/,
       "Position": {
         "X": 2404.7104,
@@ -185,6 +193,13 @@
       "Position": {
         "X": 2863.2698,
         "Y": 3271.7793
+      }
+    },
+    {
+      "ChildId": "4af88bae-fa50-45e2-8ae8-43d564c6d5f8"/*BoolToFloat*/,
+      "Position": {
+        "X": 1791.5083,
+        "Y": 3720.9985
       }
     },
     {


### PR DESCRIPTION
## I spotted an issue with [DrawMesh] being scaled down with [Transform].
Check [GamepadExample] the Dpad is looking half transparent and reveals Z fighting issue in its shading (the Z fighting is normal it's because of how I made this Dpad shape).

Issue: 
 ![issue01](https://github.com/user-attachments/assets/3ccc532a-5ac9-4b13-8028-502aa9795719)
![issue02](https://github.com/user-attachments/assets/c0adfbc2-1b90-49aa-8b30-49bc97bb0d8f)

Solution: 
![solution](https://github.com/user-attachments/assets/c37a4cba-145d-443a-8a65-7cabef96a810)

## Flat shading

Example : A torus mesh set with minimum segments in order to get a Triangle 
<img width="1077" height="431" alt="image" src="https://github.com/user-attachments/assets/c3e738f8-00eb-448a-89b7-ed2ff3173bc6" />

looks much better with flat shading 
<img width="1076" height="465" alt="image" src="https://github.com/user-attachments/assets/9c5bbb3d-7669-4f55-91d4-35d7ccf21e6f" />
