### PR TITLE
Support filenames with spaces when opening files or folders externally

### DIFF
--- a/MsForms/MsForms.cs
+++ b/MsForms/MsForms.cs
@@ -25,7 +25,8 @@ public class MsForms : ICoreSystemUiService
         var startInfo = new ProcessStartInfo
                             {
                                 FileName = "cmd",
-                                Arguments = $"/c start {uri}",
+                                // The first empty argument is the title of the console window.
+                                Arguments = $"/c start \"\" \"{uri}\"",
                             };
 
         Process.Start(startInfo);


### PR DESCRIPTION
Wrap the given URI passed to "cmd /c start" in quotes, so it can handle spaces inside filenames.

This is especially important with newer tixl versions installing themselves in "C:\Program Files". Currently, they cannot open the folders and files of the projects they ship with.

<img width="696" height="242" alt="A screenshot of an error saying 'D:/dev/test' could not be found, with a console in the background showing tixl running in 'D:/dev/test with spaces/'" src="https://github.com/user-attachments/assets/838606d4-1213-415e-bb84-504af6cfeab5" />

(In the above example I pressed the "Edit" button on one of the SVG files of "Examples.user.still.there" with tixl running in "D:/dev/test with spaces/")
