### PR TITLE
Fix Render To File Progress bar height

### DIFF
--- a/Editor/Gui/Windows/RenderExport/RenderWindow.cs
+++ b/Editor/Gui/Windows/RenderExport/RenderWindow.cs
@@ -249,9 +249,9 @@ namespace T3.Editor.Gui.Windows.RenderExport
             }
         }
 
-        private void DisplayRenderingProgress(bool success)
+        private static void DisplayRenderingProgress(bool success)
         {
-            ImGui.ProgressBar((float)Progress, new Vector2(-1, 4));
+            ImGui.ProgressBar((float)Progress, new Vector2(-1, 16));
 
             var currentTime = Playback.RunTimeInSecs;
             var durationSoFar = currentTime - _exportStartedTime;

--- a/Editor/Gui/Windows/RenderExport/RenderWindow.cs
+++ b/Editor/Gui/Windows/RenderExport/RenderWindow.cs
@@ -251,7 +251,7 @@ namespace T3.Editor.Gui.Windows.RenderExport
 
         private static void DisplayRenderingProgress(bool success)
         {
-            ImGui.ProgressBar((float)Progress, new Vector2(-1, 16));
+            ImGui.ProgressBar((float)Progress, new Vector2(-1, 16 * T3Ui.UiScaleFactor));
 
             var currentTime = Playback.RunTimeInSecs;
             var durationSoFar = currentTime - _exportStartedTime;


### PR DESCRIPTION
The progress bar height was too small, we were not able to see the percentage. 
Fixed:
<img width="421" height="122" alt="image" src="https://github.com/user-attachments/assets/8e8298d6-1216-4efd-9b7a-6345ce2d83ec" />
