### PR TITLE
Adds Local Space to Primitive SDFs

### DIFF
--- a/Operators/Lib/field/generate/sdf/BoxSDF.cs
+++ b/Operators/Lib/field/generate/sdf/BoxSDF.cs
@@ -42,8 +42,9 @@ internal sealed class BoxSDF : Instance<BoxSDF>, ITransformable
     
     public void GetPreShaderCode(CodeAssembleContext c, int inputIndex)
     {
-        c.AppendCall($"f{c}.w = fRoundedRect(p{c}.xyz, {ShaderNode}Center, {ShaderNode}Size * {ShaderNode}UniformScale * 0.5, {ShaderNode}EdgeRadius);"); 
+        c.AppendCall($"f{c}.w = fRoundedRect(p{c}.xyz, {ShaderNode}Center, {ShaderNode}Size * {ShaderNode}UniformScale * 0.5, {ShaderNode}EdgeRadius);");
         //c.AppendCall($"f{c}.xyz = p{c}.xyz;");
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
 
     [GraphParam]

--- a/Operators/Lib/field/generate/sdf/CappedTorusSDF.cs
+++ b/Operators/Lib/field/generate/sdf/CappedTorusSDF.cs
@@ -47,6 +47,7 @@ internal sealed class CappedTorusSDF : Instance<CappedTorusSDF>
 
         var n = ShaderNode;
         c.AppendCall($"f{c}.w = fCappedTorus(p{c}.xyz - {n}Center, {n}Fill, {n}Radius, {n}Thickness);");
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
 
     public void GetPostShaderCode(CodeAssembleContext c, int inputIndex)

--- a/Operators/Lib/field/generate/sdf/CapsuleLineSDF.cs
+++ b/Operators/Lib/field/generate/sdf/CapsuleLineSDF.cs
@@ -42,6 +42,7 @@ internal sealed class CapsuleLineSDF : Instance<CapsuleLineSDF>
                                 """;
 
         c.AppendCall($"f{c}.w = fCapsule(p{c} - {ShaderNode}Center, {ShaderNode}StartingPoint, {ShaderNode}EndPoint, {ShaderNode}Thickness);");
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
 
     public void GetPostShaderCode(CodeAssembleContext c, int inputIndex)

--- a/Operators/Lib/field/generate/sdf/ChainLinkSDF.cs
+++ b/Operators/Lib/field/generate/sdf/ChainLinkSDF.cs
@@ -35,6 +35,7 @@ internal sealed class ChainLinkSDF : Instance<ChainLinkSDF>
 
         var n = ShaderNode;
         c.AppendCall($"f{c}.w = fChainLink(p{c}.xyz - {n}Center, {n}Length, {n}Size, {n}Thickness);");
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
 
     public void GetPostShaderCode(CodeAssembleContext c, int inputIndex)

--- a/Operators/Lib/field/generate/sdf/CylinderSDF.cs
+++ b/Operators/Lib/field/generate/sdf/CylinderSDF.cs
@@ -51,8 +51,9 @@ internal sealed class CylinderSDF : Instance<CylinderSDF>
                                       }
                                       """;
         var a = _axisCodes0[(int)_axis];
-        c.AppendCall($"f{c}.w = fRoundedCyl(p{c}.{a}, {ShaderNode}Center.{a}, {ShaderNode}Radius *0.5, {ShaderNode}Rounding, {ShaderNode}Height *0.5 );"); 
-       // c.AppendCall($"f{c}.xyz = p{c}.xyz;");
+        c.AppendCall($"f{c}.w = fRoundedCyl(p{c}.{a}, {ShaderNode}Center.{a}, {ShaderNode}Radius *0.5, {ShaderNode}Rounding, {ShaderNode}Height *0.5 );");
+        // c.AppendCall($"f{c}.xyz = p{c}.xyz;");
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
     
     public void GetPostShaderCode(CodeAssembleContext cac, int inputIndex)

--- a/Operators/Lib/field/generate/sdf/PlaneSDF.cs
+++ b/Operators/Lib/field/generate/sdf/PlaneSDF.cs
@@ -47,6 +47,7 @@ internal sealed class PlaneSDF : Instance<PlaneSDF>
         var a = _axisCodes0[(int)_axis];
         var sign = _axisSigns[(int)_axis];
         c.AppendCall($"f{c}.w = {sign}p{c}.{a} - {ShaderNode}Center.{a};");
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
 
     private readonly string[] _axisCodes0 =

--- a/Operators/Lib/field/generate/sdf/PrismSDF.cs
+++ b/Operators/Lib/field/generate/sdf/PrismSDF.cs
@@ -90,6 +90,7 @@ internal sealed class PrismSDF : Instance<PrismSDF>
                 c.AppendCall($"f{c}.w = fHexPrism(p{c}.{a} - {n}Center.{a}, {n}Radius *0.5, {n}Length * 0.5, {n}EdgeRadius);");
                 break;
         }
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
     
 

--- a/Operators/Lib/field/generate/sdf/PyramidSDF.cs
+++ b/Operators/Lib/field/generate/sdf/PyramidSDF.cs
@@ -66,7 +66,8 @@ internal sealed class PyramidSDF : Instance<PyramidSDF>
                                       """;
         var a = _axisCodes0[(int)_axis];
         c.AppendCall($"f{c}.w = fPyramid(p{c}.{a}, {ShaderNode}Center.{a}, {ShaderNode}Scale.x * {ShaderNode}UniformScale, {ShaderNode}Scale.z * {ShaderNode}UniformScale, {ShaderNode}Scale.y * {ShaderNode}UniformScale, {ShaderNode}Rounding);"); 
-       // c.AppendCall($"f{c}.xyz = p{c}.xyz;");
+        //c.AppendCall($"f{c}.xyz = p{c}.xyz;");
+        c.AppendCall($"f{c}.xyz = p.w < 0.5 ?  p{c}.xyz : 1;"); // save local space
     }
     
     public void GetPostShaderCode(CodeAssembleContext cac, int inputIndex)


### PR DESCRIPTION
Many SDF primitives were missing the local space coordinates for UV mapping 
<img width="1539" height="496" alt="image" src="https://github.com/user-attachments/assets/ddc113b9-a38e-4f62-9d63-4748a1ce7feb" />
