### PR TITLE
Don't update project modification time if no symbols were changed

### DIFF
--- a/Editor/UiModel/EditableSymbolProject.FileHandling.cs
+++ b/Editor/UiModel/EditableSymbolProject.FileHandling.cs
@@ -71,9 +71,9 @@ internal sealed partial class EditableSymbolProject
             Log.Debug($"{CsProjectFile.Name}: Saving {modifiedSymbolUis.Length} modified symbols...");
 
             WriteAllSymbolFilesOf(modifiedSymbolUis);
+            UpdateLastModifiedDate();
         }
 
-        UpdateLastModifiedDate();
         UnmarkAsSaving();
     }
 


### PR DESCRIPTION
When the automatic save runs, it currently always updates the project csproj, regardless of any modification, creating effectively a random sorting. (Reported here: https://github.com/tixl3d/tixl/pull/718#issuecomment-3175086505)

This fixes that.

@domportera 
@newemka 