### PR TITLE
Fix Broken T3Ui reference

### DIFF
--- a/Editor/App/ProgramWindows.cs
+++ b/Editor/App/ProgramWindows.cs
@@ -7,6 +7,7 @@ using SharpDX.DXGI;
 using T3.Core.IO;
 using T3.Core.Resource;
 using T3.Core.SystemUi;
+using T3.Editor.Gui;
 using T3.Editor.Gui.UiHelpers;
 using T3.Editor.UiModel;
 using Device = SharpDX.Direct3D11.Device;
@@ -236,7 +237,7 @@ internal static class ProgramWindows
             args.Cancel = false;
 #else
             args.Cancel = true;
-    //        T3Ui.ExitDialog.ShowNextFrame();
+            T3Ui.ExitDialog.ShowNextFrame();
 #endif
         }
     }


### PR DESCRIPTION
Fixed Broken reference preventing Tixl from building in latest commit In Release Mode from IDE visual studio 

<img width="1166" height="127" alt="image" src="https://github.com/user-attachments/assets/be157922-f015-4083-9bb1-2f534fa3d240" />
