### PR TITLE
Fix ToggleAnimationPinning Tooltip

### DIFF
--- a/Editor/Gui/Windows/TimeLine/TimeControls.cs
+++ b/Editor/Gui/Windows/TimeLine/TimeControls.cs
@@ -653,12 +653,13 @@ internal static class TimeControls
                     timeLineCanvas.DopeSheetArea.PinnedParametersHashes.Clear();
                 }
             }
+            CustomComponents.TooltipForLastItem("Keep animated parameters visible",
+                                           "This can be useful when align animations between multiple operators. Toggle again to clear the visible animations.\n\n"
+                                           + UserActions.ToggleAnimationPinning.ListShortcuts()
+                                          );
         }
 
-        CustomComponents.TooltipForLastItem("Keep animated parameters visible",
-                                            "This can be useful when align animations between multiple operators. Toggle again to clear the visible animations.\n\n"
-                                            + UserActions.ToggleAnimationPinning.ListShortcuts()
-                                           );
+       
         ImGui.SameLine();
     }
 


### PR DESCRIPTION
ToggleAnimationPinning's tooltip was displayed with HoverMode's tooltip. 

Now the tooltip only appears if its button is visible.
![TiXL_I77hrwnnIQ](https://github.com/user-attachments/assets/2d856d8a-5224-4a2e-98ad-92952f7398c0)
