### PR TITLE
Clear Keyframe selection when draggin playhead

### DIFF
--- a/Editor/Gui/Windows/TimeLine/TimeLineCanvas.cs
+++ b/Editor/Gui/Windows/TimeLine/TimeLineCanvas.cs
@@ -273,6 +273,12 @@ internal sealed class TimeLineCanvas : CurveEditCanvas
             Playback.TimeInBars = draggedTime;
         }
 
+        // Add consistency: Clear selection when clicking in drag area (just like other timeline areas)
+        if (ImGui.IsItemClicked() && !ImGui.IsMouseDragging(ImGuiMouseButton.Left))
+        {
+            ClearSelection();
+        }
+
         ImGui.SetCursorPos(Vector2.Zero);
     }
 


### PR DESCRIPTION
Issue: Selection clearing consistency between clicking in the timeline and using the dragging area.
When using the dragging area the keyframe selection is not cleared but duplicate keyframe is not working. 
![TiXL_jpTL3OjfyI](https://github.com/user-attachments/assets/ed40f47d-f8da-402f-aabd-e218589ebf80)

this pull request adds selection clearing when using the dragging area: 
![TiXL_Fd8tEVlvRG](https://github.com/user-attachments/assets/c73cff32-12f0-4bc8-8c68-d8422254487c)

Of course this is a temporary solution, a better solution would be to handle the selection clearing in an other way. 
 
