### PR TITLE
Add [DataPointImportExport] and [DataPointConverter] for managing pointdata

### DIFF
--- a/Operators/Lib/point/io/DataPointConverter.cs
+++ b/Operators/Lib/point/io/DataPointConverter.cs
@@ -1,0 +1,432 @@
+﻿#nullable enable
+using System.Globalization;
+using System.Text.Json;
+using T3.Core.Utils;
+
+namespace Lib.point.io;
+
+/// <summary>
+///     Converts point data from CSV or JSON files into a GPU structured buffer of <see cref="Point" /> objects.
+///     It supports custom column mapping for CSV files and can export the converted points back to CSV or JSON.
+/// </summary>
+[Guid("a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d")]
+public sealed class DataPointConverter : Instance<DataPointConverter>
+{
+    [Input(Guid = "3c4d5e6f-7a8b-4c1d-8e9f-3a4b5c6d7e8f")]
+    public readonly InputSlot<bool> Convert = new();
+
+    [Input(Guid = "d5f6a7b8-c9d0-4e1f-2a3b-8c7d6e5f4a3b")]
+    public readonly InputSlot<string> CsvF1Mapping = new("F1");
+
+    [Input(Guid = "4c7e6d5a-8f9b-4c1d-9e2a-3b4c5d6e7f8a")]
+    public readonly InputSlot<string> CsvPosXMapping = new("Position X");
+
+    [Input(Guid = "5d6f7a8b-9c1d-4e2f-8a3b-5c4d6e7f8a9b")]
+    public readonly InputSlot<string> CsvPosYMapping = new("Position Y");
+
+    [Input(Guid = "6e5a4b3c-9d2e-4f3a-8b4c-5d6e7f8a9b1c")]
+    public readonly InputSlot<string> CsvPosZMapping = new("Position Z");
+
+    [Input(Guid = "c4e5f6a7-b8c9-4d0e-8f2a-9b8c7d6e5f4d")]
+    public readonly InputSlot<string> CsvRotWMapping = new("Rotation W");
+
+    [Input(Guid = "7f4b5c6d-8e3f-4a1b-9c2d-3e4f5a6b7c8d")]
+    public readonly InputSlot<string> CsvRotXMapping = new("Rotation X");
+
+    [Input(Guid = "8a3c2d1e-9f4a-4b5c-d6e7-f8a9b0c1d2e3")]
+    public readonly InputSlot<string> CsvRotYMapping = new("Rotation Y");
+
+    [Input(Guid = "9b2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f")]
+    public readonly InputSlot<string> CsvRotZMapping = new("Rotation Z");
+
+    [Input(Guid = "a2c1e3d4-f5a6-4b7c-8d9e-0f1a2b3c4d5e")]
+    public readonly InputSlot<string> CsvScaleXMapping = new("Scale X");
+
+    [Input(Guid = "b3d4e5f6-a7b8-4c9d-2e1f-0a9b8c7d6e5f")]
+    public readonly InputSlot<string> CsvScaleYMapping = new("Scale Y");
+
+    [Input(Guid = "c4e5f6a7-b8c9-4d0e-8f2a-9b8c7d6e5f4c")]
+    public readonly InputSlot<string> CsvScaleZMapping = new("Scale Z");
+
+    [Input(Guid = "4d5e6f7a-8b9c-4d1e-9f8a-4b5c6d7e8f9a")]
+    public readonly InputSlot<bool> Export = new();
+
+    [Input(Guid = "2b3c4d5e-6f7a-4b1c-9d8e-2f3a4b5c6d7e")]
+    public readonly InputSlot<string> ExportFilePath = new("exported_points.json");
+
+    [Input(Guid = "1a2b3c4d-5e6f-4a1b-8c9d-1e2f3a4b5c6d")]
+    public readonly InputSlot<string> FilePath = new("points.json");
+
+    [Output(Guid = "5e6f7a8b-9c1d-4e2f-8a3b-5c4d6e7f8a9b")]
+    public readonly Slot<BufferWithViews?> PointBuffer = new();
+
+    private bool _convertTriggered, _exportTriggered;
+    private List<Point>? _lastConvertedPoints;
+    private BufferWithViews? _pointBuffer;
+
+    public DataPointConverter()
+    {
+        PointBuffer.UpdateAction += Update;
+    }
+
+    private async void Update(EvaluationContext context)
+    {
+        if (MathUtils.WasTriggered(Convert.GetValue(context), ref _convertTriggered))
+        {
+            Convert.SetTypedInputValue(false);
+            await ConvertFileAsync(context);
+        }
+
+        if (MathUtils.WasTriggered(Export.GetValue(context), ref _exportTriggered))
+        {
+            Export.SetTypedInputValue(false);
+            await ExportFileAsync(context);
+        }
+
+        PointBuffer.Value = _pointBuffer;
+    }
+
+    private async Task ConvertFileAsync(EvaluationContext context)
+    {
+        var filePath = FilePath.GetValue(context);
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            Log.Warning("File path is invalid or empty.", this);
+            return;
+        }
+
+        var resolvedFilePath = Path.IsPathRooted(filePath)
+                                   ? filePath
+                                   : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, filePath);
+
+        if (!File.Exists(resolvedFilePath))
+        {
+            Log.Warning($"File does not exist: {resolvedFilePath}", this);
+            return;
+        }
+
+        Log.Debug($"Starting conversion from '{resolvedFilePath}'...", this);
+
+        try
+        {
+            var points = Path.GetExtension(resolvedFilePath).ToLowerInvariant() switch
+                             {
+                                 ".json" => await LoadFromJsonAsync(resolvedFilePath, context),
+                                 ".csv"  => await LoadFromCsvAsync(resolvedFilePath, context),
+                                 _ => throw new
+                                          NotSupportedException($"Unsupported file format '{Path.GetExtension(resolvedFilePath)}'. Please use .csv or .json.")
+                             };
+
+            UpdateGpuBufferWithPoints(ref _pointBuffer, points);
+            _lastConvertedPoints = points;
+            Log.Debug($"Successfully converted {points.Count} points from '{resolvedFilePath}'.", this);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to convert data: {ex.Message}", this);
+            UpdateGpuBufferWithPoints(ref _pointBuffer, new List<Point>());
+        }
+    }
+
+    private async Task ExportFileAsync(EvaluationContext context)
+    {
+        var filePath = ExportFilePath.GetValue(context);
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            Log.Warning("Export file path is empty.", this);
+            return;
+        }
+
+        if (_lastConvertedPoints == null || _lastConvertedPoints.Count == 0)
+        {
+            Log.Warning("No points available to export. Please convert data first.", this);
+            return;
+        }
+
+        var resolvedFilePath = Path.IsPathRooted(filePath)
+                                   ? filePath
+                                   : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, filePath);
+
+        try
+        {
+            var ext = Path.GetExtension(resolvedFilePath).ToLowerInvariant();
+            Log.Debug($"Starting export to '{resolvedFilePath}'...", this);
+
+            switch (ext)
+            {
+                case ".json":
+                    await SaveToJsonAsync(resolvedFilePath, _lastConvertedPoints);
+                    break;
+                case ".csv":
+                    await SaveToCsvAsync(resolvedFilePath, _lastConvertedPoints);
+                    break;
+                default:
+                    throw new NotSupportedException($"Unsupported export format '{ext}'. Please use .csv or .json.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to export data: {ex.Message}", this);
+        }
+    }
+
+    private async Task<List<Point>> LoadFromJsonAsync(string filePath, EvaluationContext context)
+    {
+        var jsonString = await File.ReadAllTextAsync(filePath);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var records = JsonSerializer.Deserialize<List<Dictionary<string, JsonElement>>>(jsonString, options)
+                      ?? new List<Dictionary<string, JsonElement>>();
+
+        var mapping = GetColumnMapping(context);
+        var points = new List<Point>(records.Count);
+        foreach (var record in records)
+            points.Add(ParseJsonRecord(record, mapping));
+
+        return points;
+    }
+
+    private async Task<List<Point>> LoadFromCsvAsync(string filePath, EvaluationContext context)
+    {
+        var lines = await File.ReadAllLinesAsync(filePath);
+        if (lines.Length <= 1)
+        {
+            Log.Warning("CSV file is empty or contains only a header.", this);
+            return new List<Point>();
+        }
+
+        var headers = lines[0].Split(',').Select((h, i) => (Header: h.Trim(), Index: i))
+                              .ToDictionary(x => x.Header, x => x.Index, StringComparer.OrdinalIgnoreCase);
+        var mapping = GetColumnMapping(context);
+
+        // Create a direct mapping from property name (e.g., "PosX") to column index
+        var indexMapping = mapping.ToDictionary(
+                                                kvp => kvp.Key,
+                                                kvp => headers.TryGetValue(kvp.Value, out var index) ? index : -1
+                                               );
+
+        var points = new List<Point>(lines.Length - 1);
+        for (var i = 1; i < lines.Length; i++)
+        {
+            var values = lines[i].Split(',');
+            points.Add(ParseCsvRecord(values, indexMapping));
+        }
+
+        return points;
+    }
+
+    private async Task SaveToJsonAsync(string filePath, List<Point> points)
+    {
+        var jsonPoints = points.Select(p => new
+                                                {
+                                                    Position = new { p.Position.X, p.Position.Y, p.Position.Z },
+                                                    Orientation = new { p.Orientation.W, p.Orientation.X, p.Orientation.Y, p.Orientation.Z },
+                                                    Scale = new { p.Scale.X, p.Scale.Y, p.Scale.Z },
+                                                    p.F1
+                                                }).ToList();
+
+        var options = new JsonSerializerOptions { WriteIndented = true };
+        var jsonString = JsonSerializer.Serialize(jsonPoints, options);
+        await File.WriteAllTextAsync(filePath, jsonString);
+        Log.Debug($"Successfully exported {points.Count} points to '{filePath}'.", this);
+    }
+
+    private async Task SaveToCsvAsync(string filePath, List<Point> points)
+    {
+        await using var writer = new StreamWriter(filePath);
+        await writer.WriteLineAsync("Position X,Position Y,Position Z,Rotation X,Rotation Y,Rotation Z,F1,Scale X,Scale Y,Scale Z");
+
+        foreach (var p in points)
+        {
+            var euler = ToEulerAngles(p.Orientation);
+            var line = string.Format(CultureInfo.InvariantCulture,
+                                     "{0},{1},{2},{3},{4},{5},{6},{7},{8},{9}",
+                                     p.Position.X, p.Position.Y, p.Position.Z,
+                                     euler.X, euler.Y, euler.Z,
+                                     p.F1,
+                                     p.Scale.X, p.Scale.Y, p.Scale.Z);
+            await writer.WriteLineAsync(line);
+        }
+
+        Log.Debug($"Successfully exported {points.Count} points to '{filePath}'.", this);
+    }
+
+    private Point ParseJsonRecord(IReadOnlyDictionary<string, JsonElement> record, Dictionary<string, string> mapping)
+    {
+        // Position
+        var posX = GetFloatFromJson(record, mapping.GetValueOrDefault("PosX"));
+        var posY = GetFloatFromJson(record, mapping.GetValueOrDefault("PosY"));
+        var posZ = GetFloatFromJson(record, mapping.GetValueOrDefault("PosZ"));
+
+        // Rotation
+        var rotX = GetFloatFromJson(record, mapping.GetValueOrDefault("RotX"));
+        var rotY = GetFloatFromJson(record, mapping.GetValueOrDefault("RotY"));
+        var rotZ = GetFloatFromJson(record, mapping.GetValueOrDefault("RotZ"));
+        var rotWKey = mapping.GetValueOrDefault("RotW");
+
+        Quaternion orientation;
+        var haveQuaternion = !string.IsNullOrEmpty(rotWKey) && record.ContainsKey(rotWKey);
+        if (haveQuaternion)
+        {
+            var rotW = GetFloatFromJson(record, rotWKey);
+            orientation = new Quaternion(rotX, rotY, rotZ, rotW);
+        }
+        else
+        {
+            orientation = Quaternion.CreateFromYawPitchRoll(rotY, rotX, rotZ);
+        }
+
+        // Scale
+        var scaleX = GetFloatFromJson(record, mapping.GetValueOrDefault("ScaleX"), 1);
+        var scaleY = GetFloatFromJson(record, mapping.GetValueOrDefault("ScaleY"), 1);
+        var scaleZ = GetFloatFromJson(record, mapping.GetValueOrDefault("ScaleZ"), 1);
+
+        return new Point
+                   {
+                       Position = new Vector3(posX, posY, posZ),
+                       Orientation = orientation,
+                       Scale = new Vector3(scaleX, scaleY, scaleZ),
+                       F1 = GetFloatFromJson(record, mapping.GetValueOrDefault("F1"))
+                   };
+    }
+
+    private Point ParseCsvRecord(string[] values, Dictionary<string, int> indexMapping)
+    {
+        // Position
+        var posX = GetFloatFromCsv(values, indexMapping["PosX"]);
+        var posY = GetFloatFromCsv(values, indexMapping["PosY"]);
+        var posZ = GetFloatFromCsv(values, indexMapping["PosZ"]);
+
+        // Rotation
+        var rotX = GetFloatFromCsv(values, indexMapping["RotX"]);
+        var rotY = GetFloatFromCsv(values, indexMapping["RotY"]);
+        var rotZ = GetFloatFromCsv(values, indexMapping["RotZ"]);
+        var rotWIndex = indexMapping["RotW"];
+
+        Quaternion orientation;
+        if (rotWIndex != -1)
+        {
+            var rotW = GetFloatFromCsv(values, rotWIndex);
+            orientation = new Quaternion(rotX, rotY, rotZ, rotW);
+        }
+        else
+        {
+            orientation = Quaternion.CreateFromYawPitchRoll(rotY, rotX, rotZ);
+        }
+
+        // Scale
+        var scaleX = GetFloatFromCsv(values, indexMapping["ScaleX"], 1);
+        var scaleY = GetFloatFromCsv(values, indexMapping["ScaleY"], 1);
+        var scaleZ = GetFloatFromCsv(values, indexMapping["ScaleZ"], 1);
+
+        return new Point
+                   {
+                       Position = new Vector3(posX, posY, posZ),
+                       Orientation = orientation,
+                       Scale = new Vector3(scaleX, scaleY, scaleZ),
+                       F1 = GetFloatFromCsv(values, indexMapping["F1"])
+                   };
+    }
+
+    private static float GetFloatFromJson(IReadOnlyDictionary<string, JsonElement> record, string? key, float defaultValue = 0f)
+    {
+        if (string.IsNullOrWhiteSpace(key) || !record.TryGetValue(key, out var element))
+            return defaultValue;
+
+        if (element.ValueKind == JsonValueKind.Number && element.TryGetSingle(out var num))
+            return num;
+
+        var raw = element.GetString();
+        return ParseFloatString(raw) ?? defaultValue;
+    }
+
+    private static float GetFloatFromCsv(string[] values, int index, float defaultValue = 0f)
+    {
+        if (index < 0 || index >= values.Length)
+            return defaultValue;
+
+        var raw = values[index];
+        return ParseFloatString(raw) ?? defaultValue;
+    }
+
+    private static float? ParseFloatString(string? raw)
+    {
+        var cleaned = raw?.Replace("m", string.Empty).Replace("°", string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(cleaned))
+            return null;
+
+        return float.TryParse(cleaned, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+    }
+
+    private Dictionary<string, string> GetColumnMapping(EvaluationContext context)
+    {
+        return new Dictionary<string, string>
+                   {
+                       { "PosX", CsvPosXMapping.GetValue(context) },
+                       { "PosY", CsvPosYMapping.GetValue(context) },
+                       { "PosZ", CsvPosZMapping.GetValue(context) },
+                       { "RotX", CsvRotXMapping.GetValue(context) },
+                       { "RotY", CsvRotYMapping.GetValue(context) },
+                       { "RotZ", CsvRotZMapping.GetValue(context) },
+                       { "RotW", CsvRotWMapping.GetValue(context) },
+                       { "F1", CsvF1Mapping.GetValue(context) },
+                       { "ScaleX", CsvScaleXMapping.GetValue(context) },
+                       { "ScaleY", CsvScaleYMapping.GetValue(context) },
+                       { "ScaleZ", CsvScaleZMapping.GetValue(context) }
+                   };
+    }
+
+    private static Vector3 ToEulerAngles(Quaternion q)
+    {
+        // ... implementation remains the same ...
+        Vector3 angles = new();
+        double sinrCosp = 2 * (q.W * q.X + q.Y * q.Z);
+        double cosrCosp = 1 - 2 * (q.X * q.X + q.Y * q.Y);
+        angles.X = (float)Math.Atan2(sinrCosp, cosrCosp);
+
+        double sinp = 2 * (q.W * q.Y - q.Z * q.X);
+        if (Math.Abs(sinp) >= 1)
+            angles.Y = (float)Math.CopySign(Math.PI / 2, sinp);
+        else
+            angles.Y = (float)Math.Asin(sinp);
+
+        double sinyCosp = 2 * (q.W * q.Z + q.X * q.Y);
+        double cosyCosp = 1 - 2 * (q.Y * q.Y + q.Z * q.Z);
+        angles.Z = (float)Math.Atan2(sinyCosp, cosyCosp);
+        return angles;
+    }
+
+    private void UpdateGpuBufferWithPoints(ref BufferWithViews? buffer, List<Point> list)
+    {
+        var count = list.Count;
+        var currentCount = buffer?.Buffer != null ? buffer.Buffer.Description.SizeInBytes / Point.Stride : 0;
+
+        if (count != currentCount)
+        {
+            buffer?.Dispose();
+            buffer = null;
+        }
+
+        if (count == 0) return;
+
+        var array = list.ToArray();
+        if (buffer == null)
+        {
+            buffer = new BufferWithViews();
+            ResourceManager.SetupStructuredBuffer(array, Point.Stride * count, Point.Stride, ref buffer.Buffer);
+            ResourceManager.CreateStructuredBufferSrv(buffer.Buffer, ref buffer.Srv);
+            ResourceManager.CreateStructuredBufferUav(buffer.Buffer, UnorderedAccessViewBufferFlags.None, ref buffer.Uav);
+        }
+        else
+        {
+            ResourceManager.Device.ImmediateContext.UpdateSubresource(array, buffer.Buffer);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            _pointBuffer?.Dispose();
+
+        base.Dispose(disposing);
+    }
+}

--- a/Operators/Lib/point/io/DataPointConverter.t3
+++ b/Operators/Lib/point/io/DataPointConverter.t3
@@ -1,0 +1,67 @@
+{
+  "Id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"/*DataPointConverter*/,
+  "Inputs": [
+    {
+      "Id": "1a2b3c4d-5e6f-4a1b-8c9d-1e2f3a4b5c6d"/*FilePath*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "2b3c4d5e-6f7a-4b1c-9d8e-2f3a4b5c6d7e"/*ExportFilePath*/,
+      "DefaultValue": "pointexport.json"
+    },
+    {
+      "Id": "3c4d5e6f-7a8b-4c1d-8e9f-3a4b5c6d7e8f"/*Convert*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "4c7e6d5a-8f9b-4c1d-9e2a-3b4c5d6e7f8a"/*CsvPosXMapping*/,
+      "DefaultValue": "Position X"
+    },
+    {
+      "Id": "4d5e6f7a-8b9c-4d1e-9f8a-4b5c6d7e8f9a"/*Export*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "5d6f7a8b-9c1d-4e2f-8a3b-5c4d6e7f8a9b"/*CsvPosYMapping*/,
+      "DefaultValue": "Position Y"
+    },
+    {
+      "Id": "6e5a4b3c-9d2e-4f3a-8b4c-5d6e7f8a9b1c"/*CsvPosZMapping*/,
+      "DefaultValue": "Position Z"
+    },
+    {
+      "Id": "7f4b5c6d-8e3f-4a1b-9c2d-3e4f5a6b7c8d"/*CsvRotXMapping*/,
+      "DefaultValue": "Rotation X"
+    },
+    {
+      "Id": "8a3c2d1e-9f4a-4b5c-d6e7-f8a9b0c1d2e3"/*CsvRotYMapping*/,
+      "DefaultValue": "Rotation Y"
+    },
+    {
+      "Id": "9b2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f"/*CsvRotZMapping*/,
+      "DefaultValue": "Rotation Z"
+    },
+    {
+      "Id": "a2c1e3d4-f5a6-4b7c-8d9e-0f1a2b3c4d5e"/*CsvScaleXMapping*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "b3d4e5f6-a7b8-4c9d-2e1f-0a9b8c7d6e5f"/*CsvScaleYMapping*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "c4e5f6a7-b8c9-4d0e-8f2a-9b8c7d6e5f4c"/*CsvScaleZMapping*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "c4e5f6a7-b8c9-4d0e-8f2a-9b8c7d6e5f4d"/*CsvRotWMapping*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "d5f6a7b8-c9d0-4e1f-2a3b-8c7d6e5f4a3b"/*CsvF1Mapping*/,
+      "DefaultValue": ""
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/point/io/DataPointConverter.t3ui
+++ b/Operators/Lib/point/io/DataPointConverter.t3ui
@@ -1,0 +1,155 @@
+{
+  "Id": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"/*DataPointConverter*/,
+  "Description": "Converts point data from CSV or JSON files into a GPU structured buffer of Point objects. It supports custom column mapping for CSV files and can export the converted points back to CSV or JSON.",
+  "InputUis": [
+    {
+      "InputId": "1a2b3c4d-5e6f-4a1b-8c9d-1e2f3a4b5c6d"/*FilePath*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "GroupTitle": "File Settings",
+      "Description": "The path to the input CSV or JSON file containing the point data.",
+      "Usage": "FilePath"
+    },
+    {
+      "InputId": "2b3c4d5e-6f7a-4b1c-9d8e-2f3a4b5c6d7e"/*ExportFilePath*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 975.0
+      },
+      "GroupTitle": "Export Settings",
+      "Description": "The path where the converted point data will be saved when you trigger the export. Supports .csv and .json.",
+      "Usage": "FilePath"
+    },
+    {
+      "InputId": "3c4d5e6f-7a8b-4c1d-8e9f-3a4b5c6d7e8f"/*Convert*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      },
+      "Description": "A trigger to start the conversion process. This reads the input file and generates the point buffer based on the column mappings below."
+    },
+    {
+      "InputId": "4c7e6d5a-8f9b-4c1d-9e2a-3b4c5d6e7f8a"/*CsvPosXMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 150.0
+      },
+      "GroupTitle": "Column Mapping: Position",
+      "Description": "The name of the column/property for the point's X position.",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "4d5e6f7a-8b9c-4d1e-9f8a-4b5c6d7e8f9a"/*Export*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 1050.0
+      },
+      "Description": "A trigger to save the generated point buffer to the specified ExportFilePath."
+    },
+    {
+      "InputId": "5d6f7a8b-9c1d-4e2f-8a3b-5c4d6e7f8a9b"/*CsvPosYMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 225.0
+      },
+      "Description": "The name of the column/property for the point's Y position.",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "6e5a4b3c-9d2e-4f3a-8b4c-5d6e7f8a9b1c"/*CsvPosZMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 300.0
+      },
+      "Description": "The name of the column/property for the point's Z position.",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "7f4b5c6d-8e3f-4a1b-9c2d-3e4f5a6b7c8d"/*CsvRotXMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 375.0
+      },
+      "GroupTitle": "Column Mapping: Rotation",
+      "Description": "The name of the column/property for the point's X rotation (Euler angle or Quaternion component).",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "8a3c2d1e-9f4a-4b5c-d6e7-f8a9b0c1d2e3"/*CsvRotYMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 450.0
+      },
+      "Description": "The name of the column/property for the point's Y rotation (Euler angle or Quaternion component).",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "9b2d3e4f-5a6b-4c7d-8e9f-0a1b2c3d4e5f"/*CsvRotZMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 525.0
+      },
+      "Description": "The name of the column/property for the point's Z rotation (Euler angle or Quaternion component).",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "a2c1e3d4-f5a6-4b7c-8d9e-0f1a2b3c4d5e"/*CsvScaleXMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 675.0
+      },
+      "GroupTitle": "Column Mapping: Scale",
+      "Description": "The name of the column/property for the point's X scale.",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "b3d4e5f6-a7b8-4c9d-2e1f-0a9b8c7d6e5f"/*CsvScaleYMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 750.0
+      },
+      "Description": "The name of the column/property for the point's Y scale.",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "c4e5f6a7-b8c9-4d0e-8f2a-9b8c7d6e5f4c"/*CsvScaleZMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 825.0
+      },
+      "Description": "The name of the column/property for the point's Z scale.",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "c4e5f6a7-b8c9-4d0e-8f2a-9b8c7d6e5f4d"/*CsvRotWMapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 600.0
+      },
+      "Description": "The name of the column/property for the point's W rotation (Quaternion component). If not provided, rotation is treated as Euler angles (Yaw, Pitch, Roll).",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "d5f6a7b8-c9d0-4e1f-2a3b-8c7d6e5f4a3b"/*CsvF1Mapping*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 900.0
+      },
+      "GroupTitle": "Column Mapping: Custom",
+      "Description": "The name of the column/property for a custom floating-point attribute (F1).",
+      "Usage": "Default"
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "5e6f7a8b-9c1d-4e2f-8a3b-5c4d6e7f8a9b"/*PointBuffer*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}

--- a/Operators/Lib/point/io/DataPointImportExport.cs
+++ b/Operators/Lib/point/io/DataPointImportExport.cs
@@ -1,0 +1,375 @@
+﻿#nullable enable
+using System.Globalization;
+using System.Text.Json;
+using SharpDX;
+using SharpDX.Direct3D11;
+using T3.Core.Utils;
+
+namespace Lib.point.io;
+
+/// <summary>
+///     Imports a JSON point list into a GPU structured buffer and optionally exports it again.
+///     The node keeps the imported data in an internal buffer so the points stay visible even
+///     when the import button is released.
+/// </summary>
+[Guid("d4e5f6a7-b8c9-4d0e-1f2a-9b8c7d6e5f4a")]
+public sealed class DataPointImportExport : Instance<DataPointImportExport>
+{
+    public DataPointImportExport()
+    {
+        // Use the subscription pattern – do not overwrite any existing callbacks.
+        PointBufferOut.UpdateAction += Update;
+    }
+
+    #region Update ----------------------------------------------------------
+    private async void Update(EvaluationContext context)
+    {
+        var bufferIn = PointBufferIn.GetValue(context);
+
+        var currentImportPath = ImportFilePath.GetValue(context);
+
+        // Autoload logic: Check if the path changed and is not null/whitespace, 
+        // and it's not the path we just successfully imported.
+        var pathChangedAndValid = !string.IsNullOrWhiteSpace(currentImportPath)
+                                  && !currentImportPath.Equals(_lastImportedFilePath, StringComparison.Ordinal);
+
+        // ------------------- IMPORT ------------------ -
+        var explicitImportTriggered = MathUtils.WasTriggered(Import.GetValue(context), ref _importTriggered);
+
+        if (explicitImportTriggered)
+        {
+            // Reset the button after we have detected the trigger.
+            Import.SetTypedInputValue(false);
+            await ImportFileAsync(context);
+        }
+        else if (pathChangedAndValid)
+        {
+            // Autoload triggered by file path change
+            await ImportFileAsync(context);
+        }
+
+        // ------------------- EXPORT ------------------ -
+        if (MathUtils.WasTriggered(Export.GetValue(context), ref _exportTriggered))
+        {
+            // Reset the button after we have detected the trigger.
+            Export.SetTypedInputValue(false);
+            await ExportFileAsync(context, bufferIn);
+        }
+
+        // Keep the internal buffer alive.  If we have imported data we always expose it,
+        // otherwise we forward the incoming buffer (if any) downstream.
+        PointBufferOut.Value = _pointBuffer ?? bufferIn;
+    }
+    #endregion
+
+    #region Import ------------------------------------------------------------
+    private async Task ImportFileAsync(EvaluationContext context)
+    {
+        var importPath = ImportFilePath.GetValue(context);
+        if (string.IsNullOrWhiteSpace(importPath))
+        {
+            Log.Warning("Import file path is invalid.", this);
+            return;
+        }
+
+        var resolvedPath = Path.IsPathRooted(importPath)
+                               ? importPath
+                               : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, importPath);
+
+        if (!File.Exists(resolvedPath))
+        {
+            Log.Warning($"Import file does not exist: {resolvedPath}", this);
+            // Do not update _lastImportedFilePath on non-existence to allow autoload retry when the path is corrected.
+            return;
+        }
+
+        try
+        {
+            var points = await LoadFromJsonAsync(resolvedPath);
+            UpdateGpuBufferWithPoints(ref _pointBuffer, points);
+            _lastImportedPoints = points;
+            _lastImportedFilePath = importPath; // Update tracking path on success
+            Log.Debug($"Successfully imported {points.Count} points from '{resolvedPath}'.", this);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to import data: {ex.Message}", this);
+            // Do not update _lastImportedFilePath on failure.
+        }
+    }
+    #endregion
+
+    #region Export ------------------------------------------------------------
+    private async Task ExportFileAsync(EvaluationContext context, BufferWithViews? bufferIn)
+    {
+        var exportPath = ExportFilePath.GetValue(context);
+        if (string.IsNullOrWhiteSpace(exportPath))
+        {
+            Log.Warning("Export file path is empty.", this);
+            return;
+        }
+
+        var resolvedPath = Path.IsPathRooted(exportPath)
+                               ? exportPath
+                               : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, exportPath);
+
+        // Prefer the incoming buffer if the user has connected one,
+        // otherwise fall back to the data we imported internally.
+        var pointsToExport = bufferIn != null ? ToPointList(bufferIn) : _lastImportedPoints;
+
+        if (pointsToExport == null || pointsToExport.Count == 0)
+        {
+            Log.Warning("No points available to export. Please import data or connect a point buffer.", this);
+            return;
+        }
+
+        try
+        {
+            await SaveToJsonAsync(resolvedPath, pointsToExport);
+            Log.Debug($"Successfully exported {pointsToExport.Count} points to '{resolvedPath}'.", this);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to export data: {ex.Message}", this);
+        }
+    }
+    #endregion
+
+    #region GPU Buffer ----------------------------------------------------------
+    private void UpdateGpuBufferWithPoints(ref BufferWithViews? buffer, List<Point>? list)
+    {
+        var count = list?.Count ?? 0;
+        var currentCount = buffer?.Buffer != null
+                               ? buffer.Buffer.Description.SizeInBytes / Point.Stride
+                               : 0;
+
+        // If the element count changed we must recreate the structured buffer.
+        if (count != currentCount)
+        {
+            buffer?.Dispose();
+            buffer = null;
+        }
+
+        if (count == 0)
+            return;
+
+        var array = list?.ToArray();
+
+        if (buffer == null)
+        {
+            buffer = new BufferWithViews();
+            if (array != null)
+                ResourceManager.SetupStructuredBuffer(array,
+                                                      Point.Stride * count,
+                                                      Point.Stride,
+                                                      ref buffer.Buffer);
+            ResourceManager.CreateStructuredBufferSrv(buffer.Buffer, ref buffer.Srv);
+            ResourceManager.CreateStructuredBufferUav(buffer.Buffer,
+                                                      UnorderedAccessViewBufferFlags.None,
+                                                      ref buffer.Uav);
+        }
+        else
+        {
+            // Simple sub‑resource update – fast path.
+            ResourceManager.Device.ImmediateContext.UpdateSubresource(array, buffer.Buffer);
+        }
+
+        Log.Debug($"GPU buffer updated with {count} points.", this);
+    }
+    #endregion
+
+    #region Buffer → Point List (CPU read‑back) ----------------------------------
+    private List<Point> ToPointList(BufferWithViews? bufferWithViews)
+    {
+        if (bufferWithViews?.Buffer == null)
+            return new List<Point>();
+
+        var device = ResourceManager.Device;
+        var context = device.ImmediateContext;
+        var desc = bufferWithViews.Buffer.Description;
+        var pointCount = desc.SizeInBytes / Point.Stride;
+
+        // Build a staging buffer that the CPU can read.
+        var stagingDesc = new BufferDescription
+                              {
+                                  SizeInBytes = desc.SizeInBytes,
+                                  Usage = ResourceUsage.Staging,
+                                  BindFlags = BindFlags.None,
+                                  CpuAccessFlags = CpuAccessFlags.Read,
+                                  OptionFlags = ResourceOptionFlags.BufferStructured,
+                                  StructureByteStride = desc.StructureByteStride
+                              };
+
+        using var staging = new Buffer(device, stagingDesc);
+        context.CopyResource(bufferWithViews.Buffer, staging);
+
+        var dataBox = new DataBox();
+        try
+        {
+            dataBox = context.MapSubresource(staging, 0,
+                                             MapMode.Read,
+                                             MapFlags.None);
+            using var stream = new DataStream(dataBox.DataPointer,
+                                              dataBox.RowPitch,
+                                              true,
+                                              false);
+            var points = stream.ReadRange<Point>(pointCount);
+            return points.ToList();
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Error reading GPU buffer: {ex.Message}", this);
+            return new List<Point>();
+        }
+        finally
+        {
+            if (dataBox.DataPointer != IntPtr.Zero)
+                context.UnmapSubresource(staging, 0);
+        }
+    }
+    #endregion
+
+    #region Disposal -------------------------------------------------------------
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            _pointBuffer?.Dispose();
+
+        base.Dispose(disposing);
+    }
+    #endregion
+
+    #region JSON IO --------------------------------------------------------------
+    private async Task<List<Point>> LoadFromJsonAsync(string filePath)
+    {
+        var jsonString = await File.ReadAllTextAsync(filePath);
+        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+        var records = JsonSerializer.Deserialize<List<Dictionary<string, JsonElement>>>(jsonString, options)
+                      ?? new List<Dictionary<string, JsonElement>>();
+
+        Log.Debug($"Found {records.Count} records in JSON file.", this);
+        var points = new List<Point>(records.Count);
+        foreach (var rec in records)
+            points.Add(ParseRecord(rec));
+
+        return points;
+    }
+
+    private async Task SaveToJsonAsync(string filePath, List<Point> points)
+    {
+        var jsonPoints = points.Select(p => new
+                                                {
+                                                    Position = new { p.Position.X, p.Position.Y, p.Position.Z },
+                                                    Orientation = new
+                                                                      {
+                                                                          p.Orientation.W,
+                                                                          p.Orientation.X,
+                                                                          p.Orientation.Y,
+                                                                          p.Orientation.Z
+                                                                      },
+                                                    Scale = new { p.Scale.X, p.Scale.Y, p.Scale.Z },
+                                                    p.F1
+                                                }).ToList();
+
+        var jsonString = JsonSerializer.Serialize(jsonPoints,
+                                                  new JsonSerializerOptions { WriteIndented = true });
+        await File.WriteAllTextAsync(filePath, jsonString);
+    }
+    #endregion
+
+    #region Record → Point ---------------------------------------------------------
+    private Point ParseRecord(IReadOnlyDictionary<string, JsonElement> record)
+    {
+        // Position
+        var posX = GetNestedFloat(record, "Position", "X");
+        var posY = GetNestedFloat(record, "Position", "Y");
+        var posZ = GetNestedFloat(record, "Position", "Z");
+
+        // Orientation – quaternion (fallback to identity if any component is missing)
+        var rotX = GetNestedFloat(record, "Orientation", "X");
+        var rotY = GetNestedFloat(record, "Orientation", "Y");
+        var rotZ = GetNestedFloat(record, "Orientation", "Z");
+        var rotW = GetNestedFloat(record, "Orientation", "W", 1f); // default W = 1 (unit quaternion)
+
+        // Scale (default = 1)
+        var scaleX = GetNestedFloat(record, "Scale", "X", 1);
+        var scaleY = GetNestedFloat(record, "Scale", "Y", 1);
+        var scaleZ = GetNestedFloat(record, "Scale", "Z", 1);
+
+        // Additional custom float (optional)
+        var f1 = GetFloat(record, "F1");
+
+        return new Point
+                   {
+                       Position = new Vector3(posX, posY, posZ),
+                       Orientation = new Quaternion(rotX, rotY, rotZ, rotW),
+                       Scale = new Vector3(scaleX, scaleY, scaleZ),
+                       F1 = f1
+                   };
+    }
+
+    private static float GetFloat(IReadOnlyDictionary<string, JsonElement> record, string key, float defaultValue = 0f)
+    {
+        if (!record.TryGetValue(key, out var element))
+            return defaultValue;
+
+        if (element.ValueKind == JsonValueKind.Number && element.TryGetSingle(out var num))
+            return num;
+
+        return ParseFloatString(element.GetString()) ?? defaultValue;
+    }
+
+    private static float GetNestedFloat(IReadOnlyDictionary<string, JsonElement> record,
+                                        string parentKey,
+                                        string childKey,
+                                        float defaultValue = 0f)
+    {
+        if (!record.TryGetValue(parentKey, out var parent) || parent.ValueKind != JsonValueKind.Object)
+            return defaultValue;
+
+        if (!parent.TryGetProperty(childKey, out var child))
+            return defaultValue;
+
+        if (child.ValueKind == JsonValueKind.Number && child.TryGetSingle(out var num))
+            return num;
+
+        return ParseFloatString(child.GetString()) ?? defaultValue;
+    }
+
+    private static float? ParseFloatString(string? raw)
+    {
+        var cleaned = raw?.Replace("m", string.Empty).Replace("°", string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(cleaned))
+            return null;
+
+        return float.TryParse(cleaned, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ? parsed : null;
+    }
+    #endregion
+
+    #region Fields & Slots -------------------------------------------------------
+    private bool _importTriggered, _exportTriggered;
+    private BufferWithViews? _pointBuffer; // internal GPU buffer that holds the imported data
+    private List<Point>? _lastImportedPoints; // cached point list for export when no input buffer is connected
+    private string? _lastImportedFilePath; // track the last path we successfully imported from (for autoload)
+
+    // ---------- INPUTS ----------
+    [Input(Guid = "27320742-221f-4383-8241-995083c87b8b")]
+    public readonly InputSlot<BufferWithViews> PointBufferIn = new();
+
+    [Input(Guid = "f8d41a2a-4c27-4a52-a0a2-1304cb04b80f")]
+    public readonly InputSlot<string> ImportFilePath = new("points.json");
+
+    [Input(Guid = "3e5b7c7d-8a9f-4b1e-9c2d-3e4f5a6b7c8d")]
+    public readonly InputSlot<string> ExportFilePath = new("points.json");
+
+    [Input(Guid = "a6b7c8d9-e0f1-4a2b-8c3d-4e5f6a7b8c9d")]
+    public readonly InputSlot<bool> Import = new();
+
+    [Input(Guid = "b7c8d9e0-f1a2-4b3c-9d4e-5f6a7b8c9d0e")]
+    public readonly InputSlot<bool> Export = new();
+
+    // ---------- OUTPUT ----------
+    [Output(Guid = "c8d9e0f1-a2b3-4c4d-8e5f-6a7b8c9d0e1f")]
+    public readonly Slot<BufferWithViews> PointBufferOut = new();
+    #endregion
+}

--- a/Operators/Lib/point/io/DataPointImportExport.t3
+++ b/Operators/Lib/point/io/DataPointImportExport.t3
@@ -1,0 +1,27 @@
+{
+  "Id": "d4e5f6a7-b8c9-4d0e-1f2a-9b8c7d6e5f4a"/*DataPointImportExport*/,
+  "Inputs": [
+    {
+      "Id": "27320742-221f-4383-8241-995083c87b8b"/*PointBufferIn*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "3e5b7c7d-8a9f-4b1e-9c2d-3e4f5a6b7c8d"/*ExportFilePath*/,
+      "DefaultValue": "pointexport.json"
+    },
+    {
+      "Id": "a6b7c8d9-e0f1-4a2b-8c3d-4e5f6a7b8c9d"/*Import*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "b7c8d9e0-f1a2-4b3c-9d4e-5f6a7b8c9d0e"/*Export*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "f8d41a2a-4c27-4a52-a0a2-1304cb04b80f"/*ImportFilePath*/,
+      "DefaultValue": "pointexport.json"
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/point/io/DataPointImportExport.t3ui
+++ b/Operators/Lib/point/io/DataPointImportExport.t3ui
@@ -1,0 +1,60 @@
+{
+  "Id": "d4e5f6a7-b8c9-4d0e-1f2a-9b8c7d6e5f4a"/*DataPointImportExport*/,
+  "Description": "Imports a JSON point list into a GPU structured buffer and optionally exports it again. The node keeps the imported data in an internal buffer, so the points remain visible even when the import trigger is released. It also features an autoload capability that re-imports the file when the ImportFilePath is modified.",
+  "InputUis": [
+    {
+      "InputId": "27320742-221f-4383-8241-995083c87b8b"/*PointBufferIn*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "GroupTitle": "Point Data",
+      "Description": "An optional incoming point buffer. If a buffer is connected, the Export trigger will use this data. If not connected, Export will use the last successfully imported data."
+    },
+    {
+      "InputId": "3e5b7c7d-8a9f-4b1e-9c2d-3e4f5a6b7c8d"/*ExportFilePath*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 225.0
+      },
+      "Description": "The path where the JSON file will be saved when Export is triggered.",
+      "Usage": "FilePath"
+    },
+    {
+      "InputId": "a6b7c8d9-e0f1-4a2b-8c3d-4e5f6a7b8c9d"/*Import*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 150.0
+      },
+      "Description": "A trigger to load point data from the specified ImportFilePath. The loaded data is stored internally and exposed via PointBufferOut."
+    },
+    {
+      "InputId": "b7c8d9e0-f1a2-4b3c-9d4e-5f6a7b8c9d0e"/*Export*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 300.0
+      },
+      "Description": "A trigger to save point data to the ExportFilePath. It exports from PointBufferIn if connected; otherwise, it exports the last imported data."
+    },
+    {
+      "InputId": "f8d41a2a-4c27-4a52-a0a2-1304cb04b80f"/*ImportFilePath*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      },
+      "GroupTitle": "File Operations",
+      "Description": "The path to the JSON file to import. The operator will automatically try to load the file if this path changes.",
+      "Usage": "FilePath"
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "c8d9e0f1-a2b3-4c4d-8e5f-6a7b8c9d0e1f"/*PointBufferOut*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
- DataPointImportExport:
-  - Imports/exports JSON point lists to/from a GPU structured buffer.  
-  - Features an autoload capability for import path changes.   - Retains imported data in an internal buffer.

- DataPointConverter: 
-   - Converts point data from CSV or JSON files into a GPU buffer. 
-   - Supports custom column mapping for flexible data parsing. 
-   - Allows exporting converted points back to CSV or JSON. 
-   - Handles both Euler angles and Quaternions for rotation.