### PR TITLE
Fix 810: Adding nodes downstream of alternate outputs shows a wrong connection

### DIFF
--- a/Editor/Gui/MagGraph/Interaction/PlaceholderCreation.cs
+++ b/Editor/Gui/MagGraph/Interaction/PlaceholderCreation.cs
@@ -39,10 +39,16 @@ internal sealed class PlaceholderCreation
 
         var outputLineIndex = hoverConnection.SourceItem.Instance?.Outputs.IndexOf(hoverConnection.SourceOutput) ?? 0;
 
+        var styleToUse = MagGraphConnection.ConnectionStyles.Unknown;
+        if (hoverConnection.Style is MagGraphConnection.ConnectionStyles.BottomToTop or MagGraphConnection.ConnectionStyles.RightToLeft)
+        {
+            styleToUse = hoverConnection.Style;
+        }
+
         // Add temp connection into placeholder...
         var tempConnectionIn = new MagGraphConnection
                                    {
-                                       Style = MagGraphConnection.ConnectionStyles.Unknown,
+                                       Style = styleToUse,
                                        SourcePos = hoverConnection.SourcePos,
                                        SourceItem = hoverConnection.SourceItem,
                                        SourceOutput = hoverConnection.SourceOutput,

--- a/Editor/Gui/MagGraph/Ui/MagGraphCanvas.Drawing.cs
+++ b/Editor/Gui/MagGraph/Ui/MagGraphCanvas.Drawing.cs
@@ -157,6 +157,10 @@ internal sealed partial class MagGraphView
                 {
                     var sourcePos = new Vector2(tc.SourceItem.Area.Max.X,
                                                 tc.SourceItem.Area.Min.Y + MagGraphItem.GridSize.Y * (0.5f + tc.OutputLineIndex));
+                    if (tc.Style is MagGraphConnection.ConnectionStyles.BottomToTop or MagGraphConnection.ConnectionStyles.BottomToLeft)
+                    {
+                        sourcePos = new Vector2(sourcePos.X - (tc.SourceItem.Area.GetWidth() / 2.0f), tc.SourceItem.Area.Max.Y);
+                    }
 
                     sourcePosOnScreen = TransformPosition(sourcePos);
 
@@ -198,12 +202,24 @@ internal sealed partial class MagGraphView
                 var typeColor = TypeUiRegistry.GetPropertiesForType(tc.Type).Color;
                 var d = Vector2.Distance(sourcePosOnScreen, targetPosOnScreen) / 2;
 
-                drawList.AddBezierCubic(sourcePosOnScreen,
-                                        sourcePosOnScreen + new Vector2(d, 0),
-                                        targetPosOnScreen - new Vector2(d, 0),
-                                        targetPosOnScreen,
-                                        typeColor.Fade(0.6f),
-                                        2);
+                if (tc.Style is MagGraphConnection.ConnectionStyles.BottomToTop or MagGraphConnection.ConnectionStyles.BottomToLeft)
+                {
+                    drawList.AddBezierCubic(sourcePosOnScreen,
+                                            sourcePosOnScreen,
+                                            targetPosOnScreen - new Vector2(d, 0),
+                                            targetPosOnScreen,
+                                            typeColor.Fade(0.6f),
+                                            2);
+                }
+                else
+                {
+                    drawList.AddBezierCubic(sourcePosOnScreen,
+                                            sourcePosOnScreen + new Vector2(d, 0),
+                                            targetPosOnScreen - new Vector2(d, 0),
+                                            targetPosOnScreen,
+                                            typeColor.Fade(0.6f),
+                                            2);
+                }
             }
 
             OutputSnapper.Update(_context);


### PR DESCRIPTION
Closes #810

I added a calculation of OutputLineIndex in `PlaceholderCreation.cs` so that the temporary connection line originates from the correct point when splitting a connection.

A later issue may fix the persisting connection line origin mismatch when making a placeholder for a disabled output type.

![w2x6XhlHXe](https://github.com/user-attachments/assets/0acbfe22-82f0-4b71-8de7-cf10139ded3e)
