### PR TITLE
Add [FreeDInput],[FreeDOutput] operators for FreeD protocol

### DIFF
--- a/Operators/Lib/io/freed/FreeDInput.cs
+++ b/Operators/Lib/io/freed/FreeDInput.cs
@@ -1,0 +1,357 @@
+#nullable enable
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace Lib.io.freed;
+
+[Guid("1f2e3d4c-5b6a-4988-9a0b-c1d2e3f4a5b6")]
+internal sealed class FreeDInput : Instance<FreeDInput>, IStatusProvider, ICustomDropdownHolder, IDisposable
+{
+    public FreeDInput()
+    {
+        // All outputs are updated from the same method
+        CameraDataAsDict.UpdateAction = Update;
+        IsListening.UpdateAction = Update;
+        CameraPos.UpdateAction = Update;
+        CameraRot.UpdateAction = Update;
+        CamerasAsBuffer.UpdateAction = Update;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        _printToLog = PrintToLog.GetValue(context);
+        if (_printToLog) Log.Debug($"FreeD Input: Update. Queue size: {_receivedDataQueue.Count}", this);
+
+        while (_receivedDataQueue.TryDequeue(out var data))
+            ParseFreeDDataPacket(data);
+
+        var shouldListen = Listen.GetValue(context);
+        var localIp = LocalIpAddress.GetValue(context);
+        var port = Port.GetValue(context);
+
+        var settingsChanged = shouldListen != _lastListenState || localIp != _lastLocalIp || port != _lastPort;
+        if (settingsChanged)
+        {
+            StopListening();
+            if (shouldListen) StartListening(localIp, port);
+            _lastListenState = shouldListen;
+            _lastLocalIp = localIp;
+            _lastPort = port;
+        }
+
+        IsListening.Value = _listenerTask is { Status: TaskStatus.Running };
+
+        var cameraCount = _trackedValues.Count;
+
+        if (cameraCount == 0)
+        {
+            CamerasAsBuffer.Value = null;
+            CameraDataAsDict.Value = new Dict<float>(0.0f);
+            SetStatus("Listening, no camera data received yet.", IStatusProvider.StatusLevel.Notice);
+            return;
+        }
+
+        var dict = new Dict<float>(0.0f);
+        if (_pointArrayForGpu == null || _pointArrayForGpu.Length != cameraCount)
+            _pointArrayForGpu = new Point[cameraCount];
+
+        var i = 0;
+        foreach (var (id, data) in _trackedValues.OrderBy(kvp => kvp.Key))
+        {
+            var yaw = data.Rotation.X * (MathF.PI / 180f);
+            var pitch = data.Rotation.Y * (MathF.PI / 180f);
+            var roll = data.Rotation.Z * (MathF.PI / 180f);
+            var quaternion = Quaternion.CreateFromYawPitchRoll(yaw, pitch, roll);
+            _pointArrayForGpu[i] = new Point
+                                       {
+                                           Position = data.Position,
+                                           Orientation = quaternion,
+                                           Scale = new Vector3(data.Focus, data.Zoom, data.User),
+                                           F1 = id,
+                                           Color = Vector4.One
+                                       };
+
+            var basePath = $"/{id}";
+            dict[basePath + "/Pan"] = data.Rotation.X;
+            dict[basePath + "/Tilt"] = data.Rotation.Y;
+            dict[basePath + "/Roll"] = data.Rotation.Z;
+            dict[basePath + "/PosX"] = data.Position.X;
+            dict[basePath + "/PosY"] = data.Position.Y;
+            dict[basePath + "/PosZ"] = data.Position.Z;
+            dict[basePath + "/Zoom"] = data.Zoom;
+            dict[basePath + "/Focus"] = data.Focus;
+            dict[basePath + "/User"] = data.User;
+            i++;
+        }
+
+        // Update single camera outputs
+        var selectedCameraId = CameraId.GetValue(context);
+        if (selectedCameraId < 0)
+            selectedCameraId = _trackedValues.Keys.Any() ? _trackedValues.Keys.Min() : -1;
+
+        if (selectedCameraId >= 0 && _trackedValues.TryGetValue((byte)selectedCameraId, out var selectedData))
+        {
+            CameraPos.Value = selectedData.Position;
+            CameraRot.Value = selectedData.Rotation;
+            Zoom.Value = selectedData.Zoom;
+            Focus.Value = selectedData.Focus;
+            User.Value = selectedData.User;
+        }
+
+        UpdateGpuBuffer(ref _outputBuffer, _pointArrayForGpu);
+        CamerasAsBuffer.Value = _outputBuffer;
+        CameraDataAsDict.Value = dict;
+        SetStatus($"Tracking {cameraCount} cameras.", IStatusProvider.StatusLevel.Success);
+    }
+
+    private void StartListening(string localIpStr, int port)
+    {
+        if (_listenerTask is { Status: TaskStatus.Running }) return;
+        _cancellationTokenSource = new CancellationTokenSource();
+        _listenerTask = Task.Run(() => ListenLoopAsync(localIpStr, port, _cancellationTokenSource.Token), _cancellationTokenSource.Token);
+    }
+
+    private void StopListening()
+    {
+        if (_listenerTask == null) return;
+        if (_printToLog) Log.Debug("FreeD Input: Stopping listener.", this);
+        _cancellationTokenSource?.Cancel();
+        _udpClient?.Close();
+    }
+
+    private async Task ListenLoopAsync(string localIpStr, int port, CancellationToken token)
+    {
+        try
+        {
+            var listenIp = IPAddress.Any;
+            if (!string.IsNullOrEmpty(localIpStr) && localIpStr != "0.0.0.0 (Any)" && IPAddress.TryParse(localIpStr, out var parsedIp))
+                listenIp = parsedIp;
+
+            _udpClient = new UdpClient();
+            _udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            _udpClient.Client.Bind(new IPEndPoint(listenIp, port));
+            if (_printToLog) Log.Debug($"FreeD Input: Bound to {listenIp}:{port}.", this);
+
+            while (!token.IsCancellationRequested)
+            {
+                var result = await _udpClient.ReceiveAsync(token);
+                _receivedDataQueue.Enqueue(result.Buffer);
+                CamerasAsBuffer.DirtyFlag.Invalidate();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            /* Expected */
+        }
+        catch (Exception e)
+        {
+            SetStatus($"Listener failed: {e.Message}", IStatusProvider.StatusLevel.Error);
+        }
+        finally
+        {
+            _udpClient?.Dispose();
+        }
+    }
+
+    private void ParseFreeDDataPacket(byte[] data)
+    {
+        if (data.Length != FreeDPacketLength || data[0] != FreeDIdentifier) return;
+        if (data[FreeDPacketLength - 1] != CalculateFreeDChecksum(data, FreeDPacketLength - 1)) return;
+
+        var zoom = ReadUInt24BigEndian(data, 20);
+        var focus = ReadUInt24BigEndian(data, 23);
+        var user = (data[26] << 8) | data[27];
+
+        var newData = new FreeDCameraData(
+                                          CameraId: data[1],
+                                          Rotation: new Vector3(ReadInt24BigEndian(data, 2) / AngleScale, ReadInt24BigEndian(data, 5) / AngleScale,
+                                                                ReadInt24BigEndian(data, 8) / AngleScale),
+                                          Position: new Vector3(ReadInt24BigEndian(data, 11) / PositionToMeterScale,
+                                                                ReadInt24BigEndian(data, 14) / PositionToMeterScale,
+                                                                ReadInt24BigEndian(data, 17) / PositionToMeterScale),
+                                          Zoom: zoom,
+                                          Focus: focus,
+                                          User: user
+                                         );
+        _trackedValues[newData.CameraId] = newData;
+        if (_printToLog) Log.Debug($"FreeD Input: Parsed data for CameraId {newData.CameraId}. Zoom={zoom}, Focus={focus}, User={user}", this);
+    }
+
+    private static int ReadInt24BigEndian(byte[] buffer, int offset)
+    {
+        var value = (buffer[offset] << 16) | (buffer[offset + 1] << 8) | buffer[offset + 2];
+        if ((buffer[offset] & 0x80) != 0)
+            value |= unchecked((int)0xFF000000); // Sign extend
+        return value;
+    }
+
+    private static int ReadUInt24BigEndian(byte[] buffer, int offset)
+    {
+        return (buffer[offset] << 16) | (buffer[offset + 1] << 8) | buffer[offset + 2];
+    }
+
+    private static byte CalculateFreeDChecksum(byte[] data, int length)
+    {
+        return (byte)(0x40u - data.Take(length).Aggregate(0u, (sum, val) => sum + val));
+    }
+
+    private static void UpdateGpuBuffer(ref BufferWithViews? buffer, Point[] array)
+    {
+        var num = array.Length;
+        if (num != (buffer?.Buffer.Description.SizeInBytes / Point.Stride ?? 0))
+        {
+            buffer?.Dispose();
+            buffer = new BufferWithViews();
+            ResourceManager.SetupStructuredBuffer(array, Point.Stride * num, Point.Stride, ref buffer.Buffer);
+            ResourceManager.CreateStructuredBufferSrv(buffer.Buffer, ref buffer.Srv);
+            ResourceManager.CreateStructuredBufferUav(buffer.Buffer, UnorderedAccessViewBufferFlags.None, ref buffer.Uav);
+        }
+        else
+        {
+            ResourceManager.Device.ImmediateContext.UpdateSubresource(array, buffer?.Buffer);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing)
+        {
+            StopListening();
+            _outputBuffer?.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    #region Status and Dropdown
+    private string _statusMessage = "Not listening.";
+    private IStatusProvider.StatusLevel _statusLevel = IStatusProvider.StatusLevel.Notice;
+    private readonly object _statusLock = new();
+
+    public void SetStatus(string m, IStatusProvider.StatusLevel l)
+    {
+        lock (_statusLock)
+        {
+            _statusMessage = m;
+            _statusLevel = l;
+        }
+    }
+
+    public IStatusProvider.StatusLevel GetStatusLevel()
+    {
+        lock (_statusLock)
+        {
+            return _statusLevel;
+        }
+    }
+
+    public string GetStatusMessage()
+    {
+        lock (_statusLock)
+        {
+            return _statusMessage;
+        }
+    }
+
+    string ICustomDropdownHolder.GetValueForInput(Guid id)
+    {
+        return id == LocalIpAddress.Id ? LocalIpAddress.Value : string.Empty;
+    }
+
+    IEnumerable<string> ICustomDropdownHolder.GetOptionsForInput(Guid id)
+    {
+        if (id != LocalIpAddress.Id)
+            return Empty<string>();
+
+        return _cachedIpAddresses ??= GetLocalIPv4Addresses().ToList();
+    }
+
+    void ICustomDropdownHolder.HandleResultForInput(Guid id, string? s, bool i)
+    {
+        if (!string.IsNullOrEmpty(s) && i && id == LocalIpAddress.Id) LocalIpAddress.SetTypedInputValue(s);
+    }
+
+    private static IEnumerable<string> GetLocalIPv4Addresses()
+    {
+        yield return "0.0.0.0 (Any)";
+        yield return "127.0.0.1";
+        if (!NetworkInterface.GetIsNetworkAvailable()) yield break;
+        foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (ni.OperationalStatus != OperationalStatus.Up || ni.NetworkInterfaceType == NetworkInterfaceType.Loopback) continue;
+            foreach (var ipInfo in ni.GetIPProperties().UnicastAddresses)
+                if (ipInfo.Address.AddressFamily == AddressFamily.InterNetwork)
+                    yield return ipInfo.Address.ToString();
+        }
+    }
+    #endregion
+
+    #region Fields
+    private UdpClient? _udpClient;
+    private CancellationTokenSource? _cancellationTokenSource;
+    private Task? _listenerTask;
+    private bool _lastListenState, _printToLog, _disposed;
+    private string _lastLocalIp = string.Empty;
+    private int _lastPort;
+    private readonly ConcurrentQueue<byte[]> _receivedDataQueue = new();
+    private readonly ConcurrentDictionary<byte, FreeDCameraData> _trackedValues = new();
+    private BufferWithViews? _outputBuffer;
+    private Point[]? _pointArrayForGpu;
+    private List<string>? _cachedIpAddresses;
+    private const int FreeDPacketLength = 29;
+    private const byte FreeDIdentifier = 0xD1;
+    private const float AngleScale = 32768.0f;
+    private const float PositionToMeterScale = 64000.0f;
+
+    private record struct FreeDCameraData(Vector3 Rotation, Vector3 Position, int Zoom, int Focus, byte CameraId, int User);
+    #endregion
+
+    #region Inputs & Outputs
+    [Output(Guid = "8B9C0D1E-2F3A-4B5C-6D7E-8F9A0B1C2D3E", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<BufferWithViews?> CamerasAsBuffer = new();
+
+    [Output(Guid = "2b3c4d5e-6f7a-4b9c-a0b1-c2d3e4f5a6b7", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<Dict<float>> CameraDataAsDict = new();
+
+    [Output(Guid = "3c4d5e6f-7a8b-9c0d-b1c2-d3e4f5a6b7c8", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<bool> IsListening = new();
+
+    [Output(Guid = "1A2B3C4D-5E6F-7A8B-9C0D-B1C2D3E4F5A6", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<Vector3> CameraPos = new();
+
+    [Output(Guid = "2B3C4D5E-6F7A-8B9C-0D1E-2F3A4B5C6D7E", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<Vector3> CameraRot = new();
+
+    [Output(Guid = "3C4D5E6F-7A8B-9C0D-1E2F-3A4B5C6D7E8F", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<float> Zoom = new();
+
+    [Output(Guid = "4D5E6F7A-8B9C-0D1E-2F3A-4B5C6D7E8F9A", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<float> Focus = new();
+
+    [Output(Guid = "5E6F7A8B-9C0D-1E2F-3A4B-5C6D7E8F9A0B", DirtyFlagTrigger = DirtyFlagTrigger.Animated)]
+    public readonly Slot<float> User = new();
+
+    [Input(Guid = "4b5c6d7e-8f9a-4b1c-c2d3-e4f5a6b7c8d9")]
+    public readonly InputSlot<bool> Listen = new();
+
+    [Input(Guid = "5c6d7e8f-9a0b-4c2d-d3e4-f5a6b7c8d9e0")]
+    public readonly InputSlot<string> LocalIpAddress = new("0.0.0.0 (Any)");
+
+    [Input(Guid = "6d7e8f9a-0b1c-4d3e-e4f5-a6b7c8d9e0f1")]
+    public readonly InputSlot<int> Port = new(6000);
+
+    [Input(Guid = "7e8f9a0b-1c2d-4e5f-a6b7-c8d9e0f1a2b3")]
+    public readonly InputSlot<int> CameraId = new(-1);
+
+    [Input(Guid = "8f9a0b1c-2d3e-4f5a-a6b7-c8d9e0f1a2b3")]
+    public readonly InputSlot<bool> PrintToLog = new();
+    #endregion
+}

--- a/Operators/Lib/io/freed/FreeDInput.t3
+++ b/Operators/Lib/io/freed/FreeDInput.t3
@@ -1,0 +1,27 @@
+{
+  "Id": "1f2e3d4c-5b6a-4988-9a0b-c1d2e3f4a5b6"/*FreeDInput*/,
+  "Inputs": [
+    {
+      "Id": "4b5c6d7e-8f9a-4b1c-c2d3-e4f5a6b7c8d9"/*Listen*/,
+      "DefaultValue": true
+    },
+    {
+      "Id": "5c6d7e8f-9a0b-4c2d-d3e4-f5a6b7c8d9e0"/*LocalIpAddress*/,
+      "DefaultValue": "0.0.0.0 (Any)"
+    },
+    {
+      "Id": "6d7e8f9a-0b1c-4d3e-e4f5-a6b7c8d9e0f1"/*Port*/,
+      "DefaultValue": 7000
+    },
+    {
+      "Id": "7e8f9a0b-1c2d-4e5f-a6b7-c8d9e0f1a2b3"/*CameraId*/,
+      "DefaultValue": -1
+    },
+    {
+      "Id": "8f9a0b1c-2d3e-4f5a-a6b7-c8d9e0f1a2b3"/*PrintToLog*/,
+      "DefaultValue": false
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/io/freed/FreeDInput.t3ui
+++ b/Operators/Lib/io/freed/FreeDInput.t3ui
@@ -1,0 +1,106 @@
+{
+  "Id": "1f2e3d4c-5b6a-4988-9a0b-c1d2e3f4a5b6"/*FreeDInput*/,
+  "Description": "Receives camera tracking data over UDP using the FreeD protocol. This is essential for virtual production, augmented reality, and broadcasting, allowing real-time integration with systems like Unreal Engine, Vizrt, or Aximmetry.\n\nAlso see: [FreeDOutput]",
+  "InputUis": [
+    {
+      "InputId": "4b5c6d7e-8f9a-4b1c-c2d3-e4f5a6b7c8d9"/*Listen*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Description": "Enable to open the UDP socket and begin listening for data. Disable to close the connection."
+    },
+    {
+      "InputId": "5c6d7e8f-9a0b-4c2d-d3e4-f5a6b7c8d9e0"/*LocalIpAddress*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      },
+      "Description": "The local network adapter (IP address) to listen on. '0.0.0.0 (Any)' listens on all available adapters, which is usually what you want.",
+      "Usage": "CustomDropdown"
+    },
+    {
+      "InputId": "6d7e8f9a-0b1c-4d3e-e4f5-a6b7c8d9e0f1"/*Port*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 150.0
+      },
+      "Description": "The UDP port to listen on. This must match the port the sender is broadcasting to."
+    },
+    {
+      "InputId": "7e8f9a0b-1c2d-4e5f-a6b7-c8d9e0f1a2b3"/*CameraId*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 225.0
+      },
+      "Description": "Selects a specific camera ID to output on the single-camera outputs (CameraPos, CameraRot, etc.). If set to -1, it automatically selects the camera with the lowest ID."
+    },
+    {
+      "InputId": "8f9a0b1c-2d3e-4f5a-a6b7-c8d9e0f1a2b3"/*PrintToLog*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 300.0
+      },
+      "Description": "Enable to print detailed activity and error messages to the T3 log console for debugging."
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "2b3c4d5e-6f7a-4b9c-a0b1-c2d3e4f5a6b7"/*CameraDataAsDict*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    },
+    {
+      "OutputId": "3c4d5e6f-7a8b-9c0d-b1c2-d3e4f5a6b7c8"/*IsListening*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 300.0
+      }
+    },
+    {
+      "OutputId": "8b9c0d1e-2f3a-4b5c-6d7e-8f9a0b1c2d3e"/*CamerasAsBuffer*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 400.0
+      }
+    },
+    {
+      "OutputId": "1a2b3c4d-5e6f-7a8b-9c0d-b1c2d3e4f5a6"/*CameraPos*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 500.0
+      }
+    },
+    {
+      "OutputId": "2b3c4d5e-6f7a-8b9c-0d1e-2f3a4b5c6d7e"/*CameraRot*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 600.0
+      }
+    },
+    {
+      "OutputId": "3c4d5e6f-7a8b-9c0d-1e2f-3a4b5c6d7e8f"/*Zoom*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 700.0
+      }
+    },
+    {
+      "OutputId": "4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a"/*Focus*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 800.0
+      }
+    },
+    {
+      "OutputId": "5e6f7a8b-9c0d-1e2f-3a4b-5c6d7e8f9a0b"/*User*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 900.0
+      }
+    }
+  ]
+}

--- a/Operators/Lib/io/freed/FreeDOutput.cs
+++ b/Operators/Lib/io/freed/FreeDOutput.cs
@@ -1,0 +1,297 @@
+#nullable enable
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using T3.Core.Utils;
+
+namespace Lib.io.freed;
+
+[Guid("a9b8c7d6-e5f4-4210-9876-54321fedcba0")]
+internal sealed class FreeDOutput : Instance<FreeDOutput>, IStatusProvider, ICustomDropdownHolder, IDisposable
+{
+    public FreeDOutput()
+    {
+        Command.UpdateAction = Update;
+        _writer = new BinaryWriter(_packetStream, Encoding.ASCII, true);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        _printToLog = PrintToLog.GetValue(context);
+        var shouldConnect = Connect.GetValue(context);
+        var localIp = LocalIpAddress.GetValue(context);
+        var targetIp = TargetIpAddress.GetValue(context);
+        var targetPort = TargetPort.GetValue(context);
+
+        var settingsChanged = shouldConnect != _lastConnectState || localIp != _lastLocalIp || targetIp != _lastTargetIp || targetPort != _lastTargetPort;
+        if (settingsChanged)
+        {
+            CloseSocket();
+            if (shouldConnect) OpenSocket(localIp, targetIp, targetPort);
+            _lastConnectState = shouldConnect;
+            _lastLocalIp = localIp;
+            _lastTargetIp = targetIp;
+            _lastTargetPort = targetPort;
+        }
+
+        IsConnected.Value = _udpClient != null;
+        if (_udpClient == null) return;
+
+        if (MathUtils.WasTriggered(SendTrigger.GetValue(context), ref _sendTrigger) || SendOnChange.GetValue(context))
+        {
+            var cameraId = (byte)CameraId.GetValue(context).Clamp(0, 255);
+            var rotation = Rotation.GetValue(context);
+            var position = Position.GetValue(context);
+
+            // Clamp values to their valid FreeD ranges
+            var focus = Math.Clamp(Focus.GetValue(context), 0, 0xFFFFFF);
+            var zoom = Math.Clamp(Zoom.GetValue(context), 0, 0xFFFFFF);
+            var user = Math.Clamp(User.GetValue(context), 0, 0xFFFF);
+
+            var packetBytes = BuildFreeDPacket(cameraId, rotation, position, zoom, focus, user);
+            SendPacket(packetBytes, cameraId);
+            SendTrigger.SetTypedInputValue(false);
+        }
+    }
+
+    private void SendPacket(byte[] packetBytes, byte cameraId)
+    {
+        if (_udpClient == null || _targetEndPoint == null) return;
+
+        // Fire and forget
+        Task.Run(() =>
+                 {
+                     try
+                     {
+                         _udpClient.Send(packetBytes, packetBytes.Length, _targetEndPoint);
+                         if (_printToLog) Log.Debug($"Sent FreeD packet for Camera ID {cameraId}.", this);
+                     }
+                     catch (Exception e)
+                     {
+                         SetStatus($"UDP send error: {e.Message}", IStatusProvider.StatusLevel.Warning);
+                     }
+                 });
+
+        SetStatus($"Sent FreeD packet for Camera ID {cameraId}.", IStatusProvider.StatusLevel.Success);
+    }
+
+    private byte[] BuildFreeDPacket(byte cameraId, Vector3 rotation, Vector3 position, int zoom, int focus, int user)
+    {
+        _packetStream.SetLength(0);
+        _writer.Write(FreeDIdentifier);
+        _writer.Write(cameraId);
+
+        WriteInt24BigEndian(_writer, (int)MathF.Round(rotation.X * AngleScale)); // Pan
+        WriteInt24BigEndian(_writer, (int)MathF.Round(rotation.Y * AngleScale)); // Tilt
+        WriteInt24BigEndian(_writer, (int)MathF.Round(rotation.Z * AngleScale)); // Roll
+
+        WriteInt24BigEndian(_writer, (int)MathF.Round(position.X * PositionToMeterScale)); // PosX
+        WriteInt24BigEndian(_writer, (int)MathF.Round(position.Y * PositionToMeterScale)); // PosY
+        WriteInt24BigEndian(_writer, (int)MathF.Round(position.Z * PositionToMeterScale)); // PosZ
+
+        WriteInt24BigEndian(_writer, zoom); // Zoom
+        WriteInt24BigEndian(_writer, focus); // Focus 
+
+        _writer.Write((byte)((user >> 8) & 0xFF)); // Reserved / User (16-bit)
+        _writer.Write((byte)(user & 0xFF));
+
+        var packet = _packetStream.ToArray();
+        packet[packet.Length - 1] = CalculateFreeDChecksum(packet, packet.Length - 1);
+
+        return packet;
+    }
+
+    private static void WriteInt24BigEndian(BinaryWriter writer, int value)
+    {
+        writer.Write((byte)((value >> 16) & 0xFF));
+        writer.Write((byte)((value >> 8) & 0xFF));
+        writer.Write((byte)(value & 0xFF));
+    }
+
+    private static byte CalculateFreeDChecksum(byte[] data, int length)
+    {
+        var sum = data.Take(length).Aggregate(0u, (current, val) => current + val);
+        return (byte)(0x40u - sum);
+    }
+
+    private void OpenSocket(string localIpStr, string targetIpStr, int targetPort)
+    {
+        if (!IPAddress.TryParse(localIpStr, out var localIp))
+        {
+            SetStatus($"Invalid Local IP '{localIpStr}'.", IStatusProvider.StatusLevel.Error);
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(targetIpStr))
+            targetIpStr = "255.255.255.255";
+
+        if (!IPAddress.TryParse(targetIpStr, out var targetIp))
+        {
+            SetStatus($"Invalid Target IP '{targetIpStr}'.", IStatusProvider.StatusLevel.Error);
+            return;
+        }
+
+        try
+        {
+            _udpClient = new UdpClient(new IPEndPoint(localIp, 0));
+            _targetEndPoint = new IPEndPoint(targetIp, targetPort);
+            if (_printToLog) Log.Debug($"FreeD Output: Socket bound to {localIp}, targeting {targetIp}:{targetPort}", this);
+            SetStatus($"Socket ready, sending to {targetIp}:{targetPort}", IStatusProvider.StatusLevel.Success);
+        }
+        catch (Exception e)
+        {
+            SetStatus($"Failed to open socket: {e.Message}", IStatusProvider.StatusLevel.Error);
+        }
+    }
+
+    private void CloseSocket()
+    {
+        _udpClient?.Dispose();
+        _udpClient = null;
+        if (_lastConnectState) SetStatus("Disconnected", IStatusProvider.StatusLevel.Notice);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing)
+        {
+            CloseSocket();
+            _writer.Dispose();
+            _packetStream.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    #region Status and Dropdown
+    private string _statusMessage = "Not connected.";
+    private IStatusProvider.StatusLevel _statusLevel = IStatusProvider.StatusLevel.Notice;
+    private readonly object _statusLock = new();
+
+    public void SetStatus(string m, IStatusProvider.StatusLevel l)
+    {
+        lock (_statusLock)
+        {
+            _statusMessage = m;
+            _statusLevel = l;
+        }
+    }
+
+    public IStatusProvider.StatusLevel GetStatusLevel()
+    {
+        lock (_statusLock)
+        {
+            return _statusLevel;
+        }
+    }
+
+    public string GetStatusMessage()
+    {
+        lock (_statusLock)
+        {
+            return _statusMessage;
+        }
+    }
+
+    string ICustomDropdownHolder.GetValueForInput(Guid id)
+    {
+        return id == LocalIpAddress.Id ? LocalIpAddress.Value : string.Empty;
+    }
+
+    IEnumerable<string> ICustomDropdownHolder.GetOptionsForInput(Guid id)
+    {
+        if (id != LocalIpAddress.Id)
+            return Empty<string>();
+
+        if (_cachedIpAddresses == null)
+            _cachedIpAddresses = GetLocalIPv4Addresses().ToList();
+
+        return _cachedIpAddresses;
+    }
+
+    void ICustomDropdownHolder.HandleResultForInput(Guid id, string? s, bool i)
+    {
+        if (!string.IsNullOrEmpty(s) && i && id == LocalIpAddress.Id) LocalIpAddress.SetTypedInputValue(s.Split(' ')[0]);
+    }
+
+    private static IEnumerable<string> GetLocalIPv4Addresses()
+    {
+        if (!NetworkInterface.GetIsNetworkAvailable()) yield break;
+        foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+        {
+            if (ni.OperationalStatus != OperationalStatus.Up) continue;
+            foreach (var ipInfo in ni.GetIPProperties().UnicastAddresses)
+                if (ipInfo.Address.AddressFamily == AddressFamily.InterNetwork)
+                    yield return ipInfo.Address.ToString();
+        }
+    }
+    #endregion
+
+    #region Fields
+    private UdpClient? _udpClient;
+    private IPEndPoint? _targetEndPoint;
+    private bool _lastConnectState, _sendTrigger, _printToLog, _disposed;
+    private string _lastLocalIp = string.Empty, _lastTargetIp = string.Empty;
+    private int _lastTargetPort;
+    private readonly MemoryStream _packetStream = new(FreeDPacketLength);
+    private List<string>? _cachedIpAddresses;
+    private readonly BinaryWriter _writer;
+    private const int FreeDPacketLength = 29;
+    private const byte FreeDIdentifier = 0xD1;
+    private const float AngleScale = 32768.0f;
+    private const float PositionToMeterScale = 64000.0f;
+    #endregion
+
+    #region Inputs & Outputs
+    [Output(Guid = "b0a1c2d3-e4f5-4789-aabb-ccddffeeff00")]
+    public readonly Slot<Command> Command = new();
+
+    [Output(Guid = "b0a1c2d3-e4f5-4789-aabb-ccddffeeff01")]
+    public readonly Slot<bool> IsConnected = new();
+
+    [Input(Guid = "8f9a0b1c-2d3e-4f5a-a6b7-c8d9e0f1a2b3")]
+    public readonly InputSlot<bool> Connect = new();
+
+    [Input(Guid = "9a0b1c2d-3e4f-4a6b-b7c8-d9e0f1a2b3c4")]
+    public readonly InputSlot<string> LocalIpAddress = new("0.0.0.0");
+
+    [Input(Guid = "a0b1c2d3-e4f5-4a7b-c8d9-e0f1a2b3c4d5")]
+    public readonly InputSlot<string> TargetIpAddress = new("127.0.0.1");
+
+    [Input(Guid = "b1c2d3e4-f5a6-4b8c-d9e0-f1a2b3c4d5e6")]
+    public readonly InputSlot<int> TargetPort = new(6000);
+
+    [Input(Guid = "d3e4f5a6-b7c8-4d0e-f1a2-b3c4d5e6f7a8")]
+    public readonly InputSlot<Vector3> Rotation = new();
+
+    [Input(Guid = "a6b7c8d9-e0f1-4a3b-b4c5-d6e7f8a9b0c1")]
+    public readonly InputSlot<Vector3> Position = new();
+
+    [Input(Guid = "c2d3e4f5-a6b7-4c9d-e0f1-a2b3c4d5e6f7")]
+    public readonly InputSlot<int> CameraId = new();
+
+    [Input(Guid = "d9e0f1a2-b3c4-4d6e-8f90-123456789012")]
+    public readonly InputSlot<int> Focus = new();
+
+    [Input(Guid = "e0f1a2b3-c4d5-4e7f-9012-345678901234")]
+    public readonly InputSlot<int> Zoom = new();
+
+    [Input(Guid = "f1a2b3c4-d5e6-4f8a-9123-456789012345")]
+    public readonly InputSlot<int> User = new();
+
+    [Input(Guid = "f1a2b3c4-d5e6-4f8a-8f90-123456789014")]
+    public readonly InputSlot<bool> SendOnChange = new();
+
+    [Input(Guid = "a2b3c4d5-e6f7-4a9b-8f90-123456789015")]
+    public readonly InputSlot<bool> SendTrigger = new();
+
+    [Input(Guid = "b3c4d5e6-f7a8-4b0c-8f90-123456789016")]
+    public readonly InputSlot<bool> PrintToLog = new();
+    #endregion
+}

--- a/Operators/Lib/io/freed/FreeDOutput.t3
+++ b/Operators/Lib/io/freed/FreeDOutput.t3
@@ -1,0 +1,67 @@
+{
+  "Id": "a9b8c7d6-e5f4-4210-9876-54321fedcba0"/*FreeDOutput*/,
+  "Inputs": [
+    {
+      "Id": "8f9a0b1c-2d3e-4f5a-a6b7-c8d9e0f1a2b3"/*Connect*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "9a0b1c2d-3e4f-4a6b-b7c8-d9e0f1a2b3c4"/*LocalIpAddress*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "a0b1c2d3-e4f5-4a7b-c8d9-e0f1a2b3c4d5"/*TargetIpAddress*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "a2b3c4d5-e6f7-4a9b-8f90-123456789015"/*SendTrigger*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "a6b7c8d9-e0f1-4a3b-b4c5-d6e7f8a9b0c1"/*Position*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    },
+    {
+      "Id": "b1c2d3e4-f5a6-4b8c-d9e0-f1a2b3c4d5e6"/*TargetPort*/,
+      "DefaultValue": 7000
+    },
+    {
+      "Id": "b3c4d5e6-f7a8-4b0c-8f90-123456789016"/*PrintToLog*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "c2d3e4f5-a6b7-4c9d-e0f1-a2b3c4d5e6f7"/*CameraId*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "d3e4f5a6-b7c8-4d0e-f1a2-b3c4d5e6f7a8"/*Rotation*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    },
+    {
+      "Id": "d9e0f1a2-b3c4-4d6e-8f90-123456789012"/*Focus*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "e0f1a2b3-c4d5-4e7f-9012-345678901234"/*Zoom*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "f1a2b3c4-d5e6-4f8a-8f90-123456789014"/*SendOnChange*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "f1a2b3c4-d5e6-4f8a-9123-456789012345"/*User*/,
+      "DefaultValue": 0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/io/freed/FreeDOutput.t3ui
+++ b/Operators/Lib/io/freed/FreeDOutput.t3ui
@@ -1,0 +1,129 @@
+{
+  "Id": "a9b8c7d6-e5f4-4210-9876-54321fedcba0"/*FreeDOutput*/,
+  "Description": "Sends camera tracking data over UDP using the FreeD protocol. This is essential for virtual production, augmented reality, and broadcasting, allowing real-time integration with systems like Unreal Engine, Vizrt, or Aximmetry.\n\nAlso see: [FreeDInput]",
+  "InputUis": [
+    {
+      "InputId": "8f9a0b1c-2d3e-4f5a-a6b7-c8d9e0f1a2b3"/*Connect*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Description": "Enable to open the UDP socket and begin sending data. Disable to close the connection."
+    },
+    {
+      "InputId": "9a0b1c2d-3e4f-4a6b-b7c8-d9e0f1a2b3c4"/*LocalIpAddress*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      },
+      "Description": "The local network adapter (IP address) to send from. '0.0.0.0' lets the OS decide, which is usually sufficient.",
+      "Usage": "CustomDropdown"
+    },
+    {
+      "InputId": "a0b1c2d3-e4f5-4a7b-c8d9-e0f1a2b3c4d5"/*TargetIpAddress*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 150.0
+      },
+      "Description": "The IP address of the destination device. Leave empty to broadcast to all devices on the local network (255.255.255.255).",
+      "Usage": "Default"
+    },
+    {
+      "InputId": "a2b3c4d5-e6f7-4a9b-8f90-123456789015"/*SendTrigger*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 750.0
+      },
+      "Description": "Manually sends a single FreeD packet when triggered. Useful when 'SendOnChange' is disabled."
+    },
+    {
+      "InputId": "a6b7c8d9-e0f1-4a3b-b4c5-d6e7f8a9b0c1"/*Position*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 450.0
+      },
+      "Description": "The camera's position in 3D space (X, Y, Z)."
+    },
+    {
+      "InputId": "b1c2d3e4-f5a6-4b8c-d9e0-f1a2b3c4d5e6"/*TargetPort*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 225.0
+      },
+      "Description": "The UDP port on the destination device. This must match the port the receiver is listening on."
+    },
+    {
+      "InputId": "b3c4d5e6-f7a8-4b0c-8f90-123456789016"/*PrintToLog*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 825.0
+      },
+      "Description": "Enable to print detailed activity and error messages to the T3 log console for debugging."
+    },
+    {
+      "InputId": "c2d3e4f5-a6b7-4c9d-e0f1-a2b3c4d5e6f7"/*CameraId*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 300.0
+      },
+      "Description": "A unique identifier (0-255) for the camera. The receiver uses this ID to distinguish between multiple camera sources."
+    },
+    {
+      "InputId": "d3e4f5a6-b7c8-4d0e-f1a2-b3c4d5e6f7a8"/*Rotation*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 375.0
+      },
+      "Description": "The camera's rotation as Euler angles (Pitch, Yaw, Roll) in degrees."
+    },
+    {
+      "InputId": "d9e0f1a2-b3c4-4d6e-8f90-123456789012"/*Focus*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 525.0
+      },
+      "Description": "Lens focus distance value. This is a 24-bit integer (0 - 16,777,215) from the lens encoder."
+    },
+    {
+      "InputId": "e0f1a2b3-c4d5-4e7f-9012-345678901234"/*Zoom*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 600.0
+      },
+      "Description": "Lens zoom value (focal length). This is a 24-bit integer (0 - 16,777,215) from the lens encoder."
+    },
+    {
+      "InputId": "f1a2b3c4-d5e6-4f8a-8f90-123456789014"/*SendOnChange*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 750.0
+      },
+      "Description": "If enabled, a FreeD packet is sent automatically on every frame. If disabled, packets are only sent when 'SendTrigger' is activated."
+    },
+    {
+      "InputId": "f1a2b3c4-d5e6-4f8a-9123-456789012345"/*User*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 675.0
+      },
+      "Description": "A 16-bit integer (0 - 65,535) for sending custom user-defined data, if supported by the camera system."
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "b0a1c2d3-e4f5-4789-aabb-ccddffeeff01"/*IsConnected*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      }
+    },
+    {
+      "OutputId": "b0a1c2d3-e4f5-4789-aabb-ccddffeeff00"/*Command*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 300.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Implements operators for sending and receiving camera tracking data over UDP using the FreeD protocol.

*   `FreeDOutput` sends camera position, rotation, zoom, focus,
    and user-defined data.
*   `FreeDInput` listens for and parses incoming FreeD packets,
    providing outputs for individual camera data (position,
    rotation, zoom, focus, user) and a buffer for multiple
    cameras suitable for GPU processing, along with a dictionary
    of all tracked cameras.

This functionality is essential for virtual production, augmented reality, and broadcasting, enabling real-time integration with external systems like Unreal Engine, Vizrt, or Aximmetry.