### PR TITLE
Improve and generalize the name spacer method

### DIFF
--- a/Editor/Gui/Input/FormInputs.cs
+++ b/Editor/Gui/Input/FormInputs.cs
@@ -26,7 +26,14 @@ internal static class FormInputs
         ImGui.PopFont();
         //AddVerticalSpace(20);
     }
-    
+
+    public static void AddSectionHeaderParam(string label)
+    {
+        ImGui.PushFont(Fonts.FontLarge);
+        ImGui.Text(label.AddSpacesForImGuiOutput());
+        ImGui.PopFont();
+    }
+
     public static void AddSectionSubHeader(string label)
     {
         ImGui.PushStyleColor(ImGuiCol.Text, UiColors.TextMuted.Rgba);

--- a/Editor/Gui/MagGraph/Ui/MagGraphCanvas.DrawNode.cs
+++ b/Editor/Gui/MagGraph/Ui/MagGraphCanvas.DrawNode.cs
@@ -248,7 +248,7 @@ internal sealed partial class MagGraphView
                 }
 
                 ImGui.PushFont(Fonts.FontNormal);
-                var labelSize = ImGui.CalcTextSize(name);
+                var labelSize = ImGui.CalcTextSize(name.AddSpacesForImGuiOutput());
                 ImGui.PopFont();
 
                 var paddingForPreview = hasPreview ? MagGraphItem.LineHeight + 15 : 0;
@@ -265,7 +265,7 @@ internal sealed partial class MagGraphView
                                  fontSize,
                                  labelPos,
                                  labelColor.Fade(CanvasScale.RemapAndClamp(0.3f, 0.7f, 0, 1)),
-                                 name);
+                                 name.AddSpacesForImGuiOutput());
             }
         }
 
@@ -513,7 +513,7 @@ internal sealed partial class MagGraphView
                         continue;
 
                     ImGui.PushFont(Fonts.FontSmall);
-                    var outputDefinitionName = outputLine.OutputUi.OutputDefinition.Name;
+                    var outputDefinitionName = outputLine.OutputUi.OutputDefinition.Name.AddSpacesForImGuiOutput();
                     var outputLabelSize = ImGui.CalcTextSize(outputDefinitionName) * smallFontScaleFactor;
                     ImGui.PopFont();
 

--- a/Editor/Gui/Windows/ParameterSettings.cs
+++ b/Editor/Gui/Windows/ParameterSettings.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+using ImGuiNET;
 using T3.Core.DataTypes.Vector;
 using T3.Editor.Gui.Input;
 using T3.Editor.Gui.Styling;
@@ -156,7 +156,7 @@ public sealed class ParameterSettings
                            itemMin
                            + new Vector2(8, padding + 2),
                            textColor,
-                           inputUi.InputDefinition.Name);
+                           inputUi.InputDefinition.Name.AddSpacesForImGuiOutput());
 
                 // Drag handle
                 if (ImGui.IsItemActive() || (!ImGui.IsAnyItemActive() && ImGui.IsItemHovered()))
@@ -229,7 +229,7 @@ public sealed class ParameterSettings
         {
             if (selectedInputUi != null)
             {
-                FormInputs.AddSectionHeader(selectedInputUi.InputDefinition.Name);
+                FormInputs.AddSectionHeaderParam(selectedInputUi.InputDefinition.Name);
                 ImGui.PushStyleColor(ImGuiCol.Text, UiColors.TextMuted.Rgba);
                 ImGui.TextUnformatted(selectedInputUi.Type.Name);
                 ImGui.PopStyleColor();

--- a/Editor/Gui/Windows/SettingsWindow.cs
+++ b/Editor/Gui/Windows/SettingsWindow.cs
@@ -171,11 +171,10 @@ internal sealed class SettingsWindow : Window
                                                       "This might prevent unintended user interactions while live performing with [KeyInput] operators.",
                                                       UserSettings.Defaults.EnableKeyboardShortCuts);
                     
-                    changed |= FormInputs.AddCheckBox("Readable parameter names",
+                    changed |= FormInputs.AddCheckBox("Display names with spaces",
                                                       ref UserSettings.Config.AddSpacesToParameterNames,
                                                       """
-                                                      Insert spaces to parameters names. E.g. prints "XAxisValue" becomes "X Axis Value".
-                                                      This is purely for output formatting. If you're developing, and used to PascalCase you might not need it.
+                                                      Developers use PascalCase (XAxisValue) when coding. Turn this on to display those names with spaces (X Axis Value) for easier reading.
                                                       """,
                                                       UserSettings.Defaults.AddSpacesToParameterNames);                    
                     

--- a/Editor/Gui/Windows/SymbolLib/SymbolLibrary.cs
+++ b/Editor/Gui/Windows/SymbolLib/SymbolLibrary.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using ImGuiNET;
 using T3.Core.Operator;
@@ -286,7 +286,7 @@ internal sealed class SymbolLibrary : Window
             ImGui.PushStyleColor(ImGuiCol.ButtonActive, ColorVariations.OperatorBackgroundHover.Apply(color).Rgba);
             ImGui.PushStyleColor(ImGuiCol.Text, ColorVariations.OperatorLabel.Apply(color).Rgba);
 
-            if (ImGui.Button(symbol.Name))
+            if (ImGui.Button(symbol.Name.AddSpacesForImGuiOutput()))
             {
                 //_selectedSymbol = symbol;
             }

--- a/Editor/UiModel/InputsAndTypes/InputValueUi.cs
+++ b/Editor/UiModel/InputsAndTypes/InputValueUi.cs
@@ -229,7 +229,7 @@ public abstract class InputValueUi<T> : IInputUi
                 // Draw Name
                 ImGui.PushStyleVar(ImGuiStyleVar.ButtonTextAlign, new Vector2(1.0f, 0.5f));
                 ImGui.PushStyleColor(ImGuiCol.Text, UiColors.ForegroundFull.Rgba);
-                ImGui.Button(input.Name + "##ParamName", new Vector2(ParameterNameWidth, 0.0f));
+                ImGui.Button($"{input.Name.AddSpacesForImGuiOutput()}##ParamName", new Vector2(ParameterNameWidth, 0.0f));
                 ImGui.PopStyleColor();
                 if (ImGui.BeginPopupContextItem("##parameterOptions", 0))
                 {
@@ -349,7 +349,7 @@ public abstract class InputValueUi<T> : IInputUi
 
             // Draw Name
             ImGui.PushStyleVar(ImGuiStyleVar.ButtonTextAlign, new Vector2(1.0f, 0.5f));
-            var isClicked = ImGui.Button(input.Name + "##ParamName", new Vector2(ParameterNameWidth, 0.0f));
+            var isClicked = ImGui.Button($"{input.Name.AddSpacesForImGuiOutput()}##ParamName", new Vector2(ParameterNameWidth, 0.0f));
             CustomComponents.ContextMenuForItem
                 (() =>
                  {


### PR DESCRIPTION
Improve ParameterNameSpacer.cs: it adds spaces to PascalCase names and preserves acronyms.
Example : `BoxSDF` 
before: `Box S D F` 
after: `Box SDF`

### Generalizing this method improves the readability of the whole user interface:
![NameSpacer](https://github.com/user-attachments/assets/82d67b5d-c2cb-4d3b-be55-cdf1b8c7cec3)

### Making the setting more user friendly:
<img width="586" height="147" alt="TiXL_VSBnTi9wD9" src="https://github.com/user-attachments/assets/df99aa70-fd1c-4e17-a13c-ca2a9a5d8f54" />
