### PR TITLE
Update: Gradient Editor Color Steps * T3Ui.UiScaleFactor

### DIFF
--- a/Editor/Gui/UiHelpers/GradientEditor.cs
+++ b/Editor/Gui/UiHelpers/GradientEditor.cs
@@ -113,7 +113,9 @@ public static class GradientEditor
         if (canInsertNewStep && ImGui.IsItemHovered() && !ImGui.IsItemActive())
         {
             var handleArea = GetHandleAreaForPosition(normalizedPosition);
-            drawList.AddRect(handleArea.Min + Vector2.One, handleArea.Max - Vector2.One, new Color(1f, 1f, 1f, 0.4f));
+           // drawList.AddRect(handleArea.Min + Vector2.One, handleArea.Max - Vector2.One, new Color(1f, 1f, 1f, 0.4f));
+            drawList.AddLine(handleArea.Min + new Vector2(StepHandleSize.X/2,-14), handleArea.Max - new Vector2(StepHandleSize.X / 2, 0), new Color(0.5f, 0.5f, 0.5f, 1.0f));
+           
         }
 
         // Draw CurveOverlays
@@ -220,7 +222,7 @@ public static class GradientEditor
 
         InputEditStateFlags DrawHandle(Gradient.Step step)
         {
-            var StepHandleSize = new Vector2(14, 16) * T3Ui.UiScaleFactor;
+            //var StepHandleSize = new Vector2(12, 16) * T3Ui.UiScaleFactor;
             var stepModified = InputEditStateFlags.Nothing;
             ImGui.PushID(step.Id.GetHashCode());
             var handleArea = GetHandleAreaForPosition(step.NormalizedPosition);
@@ -236,6 +238,7 @@ public static class GradientEditor
             if (ImGui.IsItemHovered(ImGuiHoveredFlags.AllowWhenBlockedByPopup))
             {
                 hoveredStep = step;
+                handleArea.Min.Y = areaOnScreen.Max.Y - StepHandleSize.Y -2*T3Ui.UiScaleFactor;
             }
 
             var isDraggedOutside = false;
@@ -483,5 +486,5 @@ public static class GradientEditor
     private const float RemoveThreshold = 15;
     private const float RequiredHeightForHandles = 20;
     private const int MinInsertHeight = 15;
-    public static Vector2 StepHandleSize => new Vector2(14, 24) * T3Ui.UiScaleFactor;
+    public static Vector2 StepHandleSize => new Vector2(9, 15) * T3Ui.UiScaleFactor;
 }


### PR DESCRIPTION
Before: TiXL 4.0.6.3, Ui Scale = 1.0
<img width="510" height="55" alt="image" src="https://github.com/user-attachments/assets/55b2477e-3e5e-462a-8cf5-a5bad5031fe0" />

After:
Ui Scale : 1.0 
<img width="341" height="51" alt="image" src="https://github.com/user-attachments/assets/ae32d3f5-0450-4930-96e4-03844ac5e4a7" />


Ui Scale = 1.5
<img width="470" height="105" alt="image" src="https://github.com/user-attachments/assets/b63c323a-8584-441f-840f-30903da6184b" />

- The color steps are scaled properly with T3Ui.UiScaleFactor.
- Inside the parameters window, with UI Scale = 1.0 the color steps were too big, hidding the gradient, so I decided to reduce the height.
- There was a double frame, the new design shift the black frame behind the white frame to make a shadow effect. 
<img width="145" height="282" alt="image" src="https://github.com/user-attachments/assets/315d7c47-4b86-4372-9428-e681ef8e0754" />
