### PR TITLE
Add: Open close operator with keyboard shortcuts (MagGraph)

### DIFF
--- a/Editor/Gui/MagGraph/States/GraphStates.cs
+++ b/Editor/Gui/MagGraph/States/GraphStates.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics;
 using ImGuiNET;
+using System.Diagnostics;
+using T3.Editor.Gui.Interaction;
+using T3.Editor.Gui.Interaction.Keyboard;
 using T3.Editor.Gui.MagGraph.Interaction;
 using T3.Editor.Gui.MagGraph.Model;
 using T3.Editor.UiModel.Commands.Graph;
@@ -80,6 +82,28 @@ internal static class GraphStates
                           if (!context.View.IsHovered)
                               return;
 
+                          // Open children or parent component with keyboard
+                          if (UserActions.CloseOperator.Triggered() && ProjectView.Focused != null)
+                          {
+                              ProjectView.Focused.TrySetCompositionOpToParent();
+                          }
+
+                          if (UserActions.OpenOperator.Triggered() && ProjectView.Focused != null)
+                          {
+                              var isWindowActive = ImGui.IsWindowFocused() || ImGui.IsWindowHovered(ImGuiHoveredFlags.AllowWhenBlockedByPopup);
+
+                              // Check if we have either an active (selected) item or a hovered item
+                              var itemToOpen = context.ActiveItem ?? context.HoveredItem;
+
+                              if (isWindowActive && itemToOpen != null && itemToOpen.Variant == MagGraphItem.Variants.Operator)
+                              {
+                                  Debug.Assert(itemToOpen.Instance != null);
+                                  if (itemToOpen.Instance.Children.Count > 0)
+                                  {
+                                      ProjectView.Focused.TrySetCompositionOpToChild(itemToOpen.Instance.SymbolChildId);
+                                  }
+                              }
+                          }
                           // Mouse click
                           var clickedDown = ImGui.IsMouseClicked(ImGuiMouseButton.Left);
                           if (!clickedDown)

--- a/Editor/Gui/MagGraph/States/GraphUiContext.cs
+++ b/Editor/Gui/MagGraph/States/GraphUiContext.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Diagnostics;
 using T3.Core.Operator;
 using T3.Editor.Gui.Graph.Dialogs;
@@ -112,6 +112,9 @@ internal sealed class GraphUiContext
     internal MagGraphItem? ActiveTargetItem;
     internal Guid ActiveTargetInputId { get; set; }
     internal MagGraphItem.Directions ActiveInputDirection { get; set; }
+
+    /** The item that is currently hovered by the mouse */
+    internal MagGraphItem? HoveredItem { get; set; }
 
     /** Only relevant while picking inputs or hovering an op while dragging connecting end. */
     internal MagGraphItem? ItemForInputSelection;


### PR DESCRIPTION
Origin: #414 Feature Request: Keybind/option to navigate in/out of nodes

This was not implemented yet for MagGraph. 