### PR TITLE
Fix Example: AudioWaveForm

### DIFF
--- a/Operators/examples/lib/io/audio/AudioWaveformExample.t3
+++ b/Operators/examples/lib/io/audio/AudioWaveformExample.t3
@@ -47,7 +47,7 @@
           "Id": "eff02108-2335-46b5-95ba-4235b9a26349"/*LeftRight*/,
           "Type": "T3.Core.DataTypes.Vector.Int2",
           "Value": {
-            "X": -779,
+            "X": -991,
             "Y": -929
           }
         }


### PR DESCRIPTION
The icon in the text was not well displayed because of the t3-icons.png update. 