### PR TITLE
Add call to get project from namespace in symbol dialog

### DIFF
--- a/Editor/Gui/Graph/Dialogs/CombineToSymbolDialog.cs
+++ b/Editor/Gui/Graph/Dialogs/CombineToSymbolDialog.cs
@@ -19,6 +19,11 @@ internal sealed class CombineToSymbolDialog : ModalDialog
         {
             var selectedChildUis = projectView.NodeSelection.GetSelectedChildUis().ToList();
             var selectedAnnotations = projectView.NodeSelection.GetSelectedNodes<Annotation>().ToList();
+
+            if (_projectToCopyTo == null)
+            {
+                EditableSymbolProject.TryGetEditableProjectOfNamespace(nameSpace, out _projectToCopyTo);
+            }
             
             _ = SymbolModificationInputs.DrawProjectDropdown(ref nameSpace, ref _projectToCopyTo);
 


### PR DESCRIPTION
Closes https://github.com/tixl3d/tixl/issues/778 - When combing operators the project and namespace should be inferred

Synopsis of changes:

1. I added a call to `EditableSymbolProject.TryGetEditableProjectOfNamespace` in the symbol dialog before the project dropdown is drawn.
This pre-fills the project dropdown with the current editable project and namespace.

