### PR TITLE
Add: Copy Selected Symbol Name to Clipboard to MagGraph context menu

### DIFF
--- a/Editor/Gui/MagGraph/Interaction/GraphContextMenu.cs
+++ b/Editor/Gui/MagGraph/Interaction/GraphContextMenu.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+using ImGuiNET;
 using T3.Core.DataTypes;
 using T3.Core.SystemUi;
 using T3.Editor.Gui.Interaction;
@@ -362,6 +362,13 @@ internal static class GraphContextMenu
                     CoreUi.Instance.OpenWithDefaultApplication(exportDir);
                     break;
             }
+        }
+
+        ImGui.Separator();
+ 
+        if (ImGui.MenuItem("Copy Symbol Name to Clipboard", oneOpSelected))
+        {
+            ImGui.SetClipboardText("[" + $"{selectedChildUis[0].SymbolChild.ReadableName}" + "]");
         }
 
         // TODO: Clarify if required


### PR DESCRIPTION
Useful when editing descriptions or telling someone about a specific symbol.
<img width="364" height="516" alt="image" src="https://github.com/user-attachments/assets/db9c2b33-f39b-451a-bfa7-e6dce1b4abf0" />
