### PR TITLE
Fix: MidiSysexOutput NullReferenceException Crash

### DIFF
--- a/Operators/Lib/io/midi/MidiSysexOutput.cs
+++ b/Operators/Lib/io/midi/MidiSysexOutput.cs
@@ -135,7 +135,9 @@ internal sealed class MidiSysexOutput : Instance<MidiSysexOutput>
             }
 
             _lastErrorMessage = !foundDevice ? $"Can't find MidiDevice {deviceName}" : null;
-            Log.Warning(_lastErrorMessage, this);
+            
+            if(_lastErrorMessage != null)
+                Log.Warning(_lastErrorMessage, this);
             
             _initialized = true;
         }


### PR DESCRIPTION
Fixed missed null check