### PR TITLE
fix: crash when returning to audio clip timeline without a defined audio input

### DIFF
--- a/Editor/Gui/Windows/TimeLine/PlaybackSettingsPopup.cs
+++ b/Editor/Gui/Windows/TimeLine/PlaybackSettingsPopup.cs
@@ -443,7 +443,8 @@ internal static class PlaybackSettingsPopup
                 Bass.Init();
                 Bass.Start();
                 Playback.Current.Bpm = settings.AudioClips[0].Bpm;
-                Playback.Current.Settings.Syncing = PlaybackSettings.SyncModes.Timeline;
+                if (Playback.Current.Settings != null)
+                    Playback.Current.Settings.Syncing = PlaybackSettings.SyncModes.Timeline;
             }
 
             UserSettings.Config.ShowTimeline = true;


### PR DESCRIPTION
Reproducer:

- Enable project audio
- In `Project Sound Track` Select some audio clip
- Switch to `External Device`, pick some external audio interface
- Save & Exit
- Unplug audio interface
- Go back to `Playback Settings` (Audio interface picker is empty)
- Return to project sound track, Tixl crashes

This check != null fixes it.