### PR TITLE
Update/Fix: Search results, relevancy weighting, pascal case match

### DIFF
--- a/Editor/UiModel/Helpers/SymbolFilter.cs
+++ b/Editor/UiModel/Helpers/SymbolFilter.cs
@@ -124,13 +124,13 @@ internal sealed class SymbolFilter
                  if (symbolUiSymbol.InputDefinitions.Count == 0 || symbolUiSymbol.InputDefinitions[0].ValueType != _inputType)
                      continue;
 
-                var matchingInputDef = symbolUiSymbol.GetInputMatchingType(FilterInputType);
+                 var matchingInputDef = symbolUiSymbol.GetInputMatchingType(FilterInputType);
                 
-                if (matchingInputDef == null)
-                    continue;
+                 if (matchingInputDef == null)
+                     continue;
 
-                if (OnlyMultiInputs && !symbolUiSymbol.InputDefinitions[0].IsMultiInput)
-                    continue;
+                 if (OnlyMultiInputs && !symbolUiSymbol.InputDefinitions[0].IsMultiInput)
+                     continue;
             }
 
             if (_outputType != null)


### PR DESCRIPTION
- Removed the hard cap of 30 search results (Default limit 0 is now unlimited) 
  - This still allows for setting a defined limit for classes like RandomPromptGenerator.cs
- Updated relevancy weighting with less variation between string match types
- Fixed pascal case match to take into account the last letter typed in search
- Filtered search results to only show relevant results (score of 10+)
  - This still allows searching for obsolete and "_" ops directly with string matching, but filters out of generic search
- Moved relevancy boost by usage amount to the bottom, only boost if the result is already relevant (score of 10+)
  - This avoids boosting operators that are used a lot (like Text) above the most relevant results