### PR TITLE
fix: add a peak LED on signal display, avoid overflow

### DIFF
--- a/Core/Audio/WasapiAudioInput.cs
+++ b/Core/Audio/WasapiAudioInput.cs
@@ -193,8 +193,7 @@ public static class WasapiAudioInput
         var playbackSettings = Playback.Current?.Settings;
         if (playbackSettings == null) 
             return length;
-        
-        
+
         AudioAnalysis.ProcessUpdate(playbackSettings?.AudioGainFactor?? 1,
                                     playbackSettings?.AudioDecayFactor?? 0.9f);
 
@@ -227,5 +226,4 @@ public static class WasapiAudioInput
     /// This is only used of the gain meter in the playback settings dialog.
     /// </summary>
     public static float DecayingAudioLevel => (float)(_lastAudioLevel / Math.Max(1, (Playback.RunTimeInSecs - LastUpdateTime) * 100));
-    
 }

--- a/Editor/Gui/Windows/TimeLine/PlaybackSettingsPopup.cs
+++ b/Editor/Gui/Windows/TimeLine/PlaybackSettingsPopup.cs
@@ -6,7 +6,6 @@ using ManagedBass;
 using ManagedBass.Wasapi;
 using T3.Core.Animation;
 using T3.Core.Audio;
-using T3.Core.DataTypes.Vector;
 using T3.Core.IO;
 using T3.Core.Operator;
 using T3.Editor.Gui.Audio;
@@ -258,13 +257,13 @@ internal static class PlaybackSettingsPopup
                         modified = true;
                     }
 
-                    modified |= FormInputs.AddFloat("AudioDecay", ref settings.AudioDecayFactor,
-                                        0.001f,
-                                        1f,
-                                        0.01f,
-                                        true, true,
-                                        "The decay factors controls the impact of [AudioReaction] when AttackMode. Good values strongly depend on style, loudness and variation of input signal.",
-                                        0.9f);
+                    modified |= FormInputs.AddFloat("Audio Decay", ref settings.AudioDecayFactor,
+                                                    0.001f,
+                                                    1f,
+                                                    0.01f,
+                                                    true, true,
+                                                    "The decay factors controls the impact of [AudioReaction] when AttackMode. Good values strongly depend on style, loudness and variation of input signal.",
+                                                    0.9f);
                     
                     if (filepathModified)
                     {
@@ -297,30 +296,30 @@ internal static class PlaybackSettingsPopup
 
 
                     modified |= FormInputs.AddCheckBox("Enable audio beat lock",
-                                           ref settings.EnableAudioBeatLocking,
-                                           """
-                                           If enabled, the editor will look for transient bass, hihats and snares and attempt to look the playback onto the incoming audio signal.
-                                           To use this, start by tapping the base beat (e.g. with X) then tap the beginning of the bar with (e.g. with X).
-                                           From now on, you will see the BPM be constantly sliding to look onto the beat).
-                                           """,
-                                           true
-                                          );
+                                                       ref settings.EnableAudioBeatLocking,
+                                                       """
+                                                       If enabled, the editor will look for transient bass, hihats and snares and attempt to look the playback onto the incoming audio signal.
+                                                       To use this, start by tapping the base beat (e.g. with X) then tap the beginning of the bar with (e.g. with X).
+                                                       From now on, you will see the BPM be constantly sliding to look onto the beat).
+                                                       """,
+                                                       true
+                                                      );
                     FormInputs.AddVerticalSpace();
                 }
 
                 if (!settings.EnableAudioBeatLocking)
                 {
                     modified |= FormInputs.AddFloat("BPM",
-                                                  ref settings.Bpm,
-                                                  0,
-                                                  1000,
-                                                  0.02f,
-                                                  true, true,
-                                                  """
-                                                  In T3 animation units are in bars.
-                                                  The BPM rate controls the animation speed of your project.
-                                                  """,
-                                                  120);
+                                                    ref settings.Bpm,
+                                                    0,
+                                                    1000,
+                                                    0.02f,
+                                                    true, true,
+                                                    """
+                                                    In T3 animation units are in bars.
+                                                    The BPM rate controls the animation speed of your project.
+                                                    """,
+                                                    120);
                 }
 
                 FormInputs.SetIndentToParameters();
@@ -338,46 +337,54 @@ internal static class PlaybackSettingsPopup
                 
                 FormInputs.AddVerticalSpace();
 
-                
                 // var isInitialized = playback is BeatTimingPlayback;
                 // if (!isInitialized)
                 // {
                 //     playback = new BeatTimingPlayback();
                 // }
 
-                modified |= FormInputs.AddFloat("AudioGain", ref settings.AudioGainFactor , 0.01f, 100, 0.01f, true, true,
-                                    """Can be used to adjust the input signal (e.g. in live situation where the input level might vary.""",
-                                    1);
+                modified |= FormInputs.AddFloat("Audio Gain", ref settings.AudioGainFactor , 0.01f, 100, 0.01f, true, true,
+                                                "Can be used to adjust the input signal (e.g. in live situation where the input level might vary.",
+                                                1);
 
-                modified |= FormInputs.AddFloat("AudioDecay", ref settings.AudioDecayFactor,
-                                    0.001f,
-                                    1f,
-                                    0.01f,
-                                    true, true,
-                                    "The decay factors controls the impact of [AudioReaction] when AttackMode. Good values strongly depend on style, loudness and variation of input signal.",
-                                    0.9f);
-                
+                modified |= FormInputs.AddFloat("Audio Decay", ref settings.AudioDecayFactor,
+                                                0.001f,
+                                                1f,
+                                                0.01f,
+                                                true, true,
+                                                "The decay factors controls the impact of [AudioReaction] when AttackMode. Good values strongly depend on style, loudness and variation of input signal.",
+                                                0.9f);
 
                 // Input meter
-                ImGui.PushStyleVar(ImGuiStyleVar.Alpha, 0.5f * ImGui.GetStyle().Alpha);
+                var level = settings.AudioGainFactor * WasapiAudioInput.DecayingAudioLevel * 0.03f;
+                var dl = ImGui.GetWindowDrawList();
                 FormInputs.DrawInputLabel("Input Level");
-                ImGui.PopStyleVar();
-                
                 ImGui.InvisibleButton("##gainMeter", new Vector2(-1, ImGui.GetFrameHeight()));
-                // ImGui.GetContentRegionAvail()
+
+                var normalizedLevel =  level / 644f;
+                _smoothedLevel = normalizedLevel > _smoothedLevel ? normalizedLevel : Math.Max(normalizedLevel, _smoothedLevel - 2f * ImGui.GetIO().DeltaTime);
+
                 var min = ImGui.GetItemRectMin();
                 var max = ImGui.GetItemRectMax();
-                // max.X -= 100f; // * T3Ui.UiScaleFactor;
-                max.X = ImGui.GetContentRegionAvail().X;
-                var dl = ImGui.GetWindowDrawList();
+                var paddedWidth = (max.X - min.X) * .80f;
+                var paddedHeight = (max.Y - min.Y) / 3f;
+                max.X = min.X + paddedWidth;
 
-                var level = settings.AudioGainFactor * WasapiAudioInput.DecayingAudioLevel * 0.03f;
-                
+                // A full gradient with green-ish at bottom, and orange-ish at the top
+                dl.AddRectFilledMultiColor(new Vector2(min.X, min.Y + paddedHeight),
+                                           new Vector2(min.X + paddedWidth, max.Y - paddedHeight),
+                                           UiColors.StatusControlled, UiColors.StatusWarning,
+                                           UiColors.StatusWarning, UiColors.StatusControlled);
 
-                // dl.AddRectFilled(min, new Vector2(Math.Min(min.X + level, max.X), max.Y), UiColors.BackgroundHover);
-                dl.AddRectFilled(min, new Vector2(Math.Min(min.X + level, max.X), max.Y), UiColors.BackgroundHover);
-                dl.AddRectFilled(new Vector2(max.X,min.Y) , new Vector2(max.X + 50f, max.Y), 
-                                 level < 644f ? UiColors.BackgroundHover : UiColors.StatusError);
+                // We cover it according to smoothed level (the gain range is inverted)
+                dl.AddRectFilled(new Vector2(max.X, min.Y + paddedHeight),
+                                 new Vector2(Math.Min(min.X + paddedWidth * _smoothedLevel, min.X + paddedWidth), max.Y - paddedHeight),
+                                 UiColors.BackgroundHover);
+
+                // Peak LED
+                dl.AddRectFilled(new Vector2(max.X + 5f * T3Ui.UiScaleFactor, min.Y + paddedHeight),
+                                 new Vector2(max.X + 25f * T3Ui.UiScaleFactor, max.Y - paddedHeight),
+                                 normalizedLevel < 1f ? UiColors.BackgroundHover : UiColors.StatusError);
                 FormInputs.DrawInputLabel("Input Device");
                 ImGui.BeginGroup();
 
@@ -504,6 +511,7 @@ internal static class PlaybackSettingsPopup
     /** We use this for modification inside the input field and checking if path is valid before actually assigning it to the soundtrack */
     private static string? _tempSoundtrackFilepathForEdit = string.Empty;
 
+    private static float _smoothedLevel = 0f;
     private static string _warningMessage = string.Empty;
     public const string PlaybackSettingsPopupId = "##PlaybackSettings";
     private const string AllFilesAudioFilesMp3WavOggMp3WavOgg = "Audio files (mp3,wav,ogg)|*.mp3;*.wav;*.ogg";


### PR DESCRIPTION
- ensure bass api level is >0 (signed integer overflowing on very loud music and full-scale white noise)
- replace slider with a custom meter:
  - use better padding (meter went beyond panel limits on overdriven signals)
  - add a peak LED
  - add some ballistic to smooth out level decay
- fix few labels
 