### PR TITLE
Fixed leaving focus mode (F12)

### DIFF
--- a/Editor/Gui/Windows/Layouts/LayoutHandling.cs
+++ b/Editor/Gui/Windows/Layouts/LayoutHandling.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.IO;
 using ImGuiNET;
@@ -83,7 +83,6 @@ internal static class LayoutHandling
     public static void LoadAndApplyLayoutOrFocusMode(Layouts layoutId)
     {
         var index = (int)layoutId;
-        //var isFocusMode = index == 11;
 
         var relativePath = Path.Combine(LayoutSubfolder, GetLayoutFilename(index));
         if (!UserData.TryLoadingOrWriteDefaults(relativePath, out var jsonBlob))
@@ -103,8 +102,10 @@ internal static class LayoutHandling
             graphWindow.SetWindowToNormal();
         }
 
-        UserSettings.Config.FocusMode = layoutId == Layouts.FocusMode;
-        UserSettings.Config.WindowLayoutIndex = index;
+        var isFocusMode = layoutId == Layouts.FocusMode;
+        UserSettings.Config.FocusMode = isFocusMode;
+        if (!isFocusMode)
+            UserSettings.Config.WindowLayoutIndex = index;
     }
 
     public static string GraphPrefix => "Graph View##";

--- a/Editor/Gui/Windows/Layouts/UiConfig.cs
+++ b/Editor/Gui/Windows/Layouts/UiConfig.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using T3.Core.Animation;
 using T3.Core.Operator;
 using T3.Editor.Gui.UiHelpers;
@@ -21,11 +21,11 @@ internal static class UiConfig
 
         var shouldBeFocusMode = !UserSettings.Config.FocusMode;
 
-        if (!OutputWindow.TryGetPrimaryOutputWindow(out var oldOutputWindow))
-            return;
-
         if (shouldBeFocusMode)
         {
+            if (!OutputWindow.TryGetPrimaryOutputWindow(out var oldOutputWindow))
+                return;
+
             oldOutputWindow.Pinning.TryGetPinnedOrSelectedInstance(out var instance, out _);
             activeComponents.GraphImageBackground.OutputInstance = instance;
         }
@@ -34,7 +34,7 @@ internal static class UiConfig
         UserSettings.Config.ShowToolbar = shouldBeFocusMode;
         
         ToggleAllUiElements();
-        
+
         LayoutHandling.LoadAndApplyLayoutOrFocusMode(shouldBeFocusMode
                                                          ? LayoutHandling.Layouts.FocusMode
                                                          : (LayoutHandling.Layouts)UserSettings.Config.WindowLayoutIndex);


### PR DESCRIPTION
Restores previous functionality of the focus mode without impacting new Skill Quest stuff.
`LoadAndApplyLayoutOrFocusMode()` setting `UserSettings.Config.FocusMode` is a questionable choice and I suggest looking over it, but this works for now.