### PR TITLE
fix cs multidispatch call index

### DIFF
--- a/Operators/TypeOperators/Gfx/ComputeShaderStage.cs
+++ b/Operators/TypeOperators/Gfx/ComputeShaderStage.cs
@@ -85,7 +85,7 @@ public sealed class ComputeShaderStage : Instance<ComputeShaderStage>, IRenderSt
         // Dispatch the shader
         for (int i = 0; i < callCount; i++)
         {
-            if (i > 0)
+            if (callCount>1)
             {
                 _dispatchParameters.DispatchCallIndex = i;
                 ResourceManager.SetupConstBuffer(_dispatchParameters, ref _dispatchCallParameterBuffer);


### PR DESCRIPTION
sending the right index value for i==0 (does not affect most common case of callCount==1)