### PR TITLE
Annotations - allow copy/paste

### DIFF
--- a/Editor/Gui/MagGraph/Interaction/AnnotationRenaming.cs
+++ b/Editor/Gui/MagGraph/Interaction/AnnotationRenaming.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using ImGuiNET;
 using T3.Editor.Gui.MagGraph.States;
 using T3.Editor.Gui.Styling;
@@ -10,15 +10,42 @@ using T3.SystemUi;
 namespace T3.Editor.Gui.MagGraph.Interaction;
 
 /// <summary>
-/// Handles renaming annotation titles
+/// Handles the UI and logic for renaming annotation titles and labels within the graph editor.
+/// This class manages the editing state, input buffers, and command execution for undo/redo support.
 /// </summary>
 internal static class AnnotationRenaming
 {
+    /// <summary>
+    /// Buffer for the annotation label being edited.
+    /// </summary>
+    private static string _labelBuffer = string.Empty;
+    /// <summary>
+    /// Buffer for the annotation title/description being edited.
+    /// </summary>
+    private static string _titleBuffer = string.Empty;
+    /// <summary>
+    /// Stores the original title to detect changes and support undo/redo.
+    /// </summary>
+    private static string? _originalTitle;
+    /// <summary>
+    /// Tracks the currently focused annotation for renaming.
+    /// </summary>
+    private static Guid _focusedAnnotationId;
+    /// <summary>
+    /// Command used for undo/redo of annotation text changes.
+    /// </summary>
+    private static ChangeAnnotationTextCommand? _changeAnnotationTextCommand;
+
+    /// <summary>
+    /// Draws the annotation renaming UI and handles user interaction.
+    /// </summary>
+    /// <param name="context">The current graph UI context.</param>
     public static void Draw(GraphUiContext context)
     {
         var shouldClose = false;
         var annotationId = context.ActiveAnnotationId;
 
+        // If the annotation is not found, reset state and exit
         if (!context.Layout.Annotations.TryGetValue(annotationId, out var magAnnotation))
         {
             context.ActiveAnnotationId = Guid.Empty;
@@ -29,86 +56,66 @@ internal static class AnnotationRenaming
         var annotation = magAnnotation.Annotation;
         var screenArea = context.View.TransformRect(ImRect.RectWithSize(annotation.PosOnCanvas, annotation.Size));
 
+        // Initialize buffers and command when dialog is first opened
         var justOpened = _focusedAnnotationId != annotationId;
         if (justOpened)
         {
             ImGui.SetKeyboardFocusHere();
             _focusedAnnotationId = annotationId;
             _changeAnnotationTextCommand = new ChangeAnnotationTextCommand(annotation, annotation.Title);
+            _labelBuffer = annotation.Label ?? string.Empty;
+            _titleBuffer = annotation.Title ?? string.Empty;
+            _originalTitle = annotation.Title;
         }
 
-        // Edit label
-        var positionInScreen = screenArea.Min;
+        // --- Label editing UI ---
+        ImGui.SetCursorScreenPos(screenArea.Min);
+        ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(4, 4));
+        ImGui.SetNextItemWidth(350);
+        ImGui.InputText("##renameAnnotationLabel", ref _labelBuffer, 256, ImGuiInputTextFlags.AutoSelectAll);
+        ImGui.PopStyleVar();
+        ImGui.GetWindowDrawList().AddRect(ImGui.GetItemRectMin(), ImGui.GetItemRectMax(), UiColors.ForegroundFull.Fade(0.1f));
+        // Draw placeholder if label is empty
+        if (string.IsNullOrEmpty(_labelBuffer))
         {
-            var labelPos = positionInScreen; // - new Vector2(2, Fonts.FontNormal.FontSize + 8);
-            ImGui.SetCursorScreenPos(labelPos);
-            ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(4,4));
-
-            ImGui.SetNextItemWidth(350);
-            ImGui.InputText("##renameAnnotationLabel", ref annotation.Label, 256, ImGuiInputTextFlags.AutoSelectAll);
-            ImGui.PopStyleVar();
-
-            ImGui.GetWindowDrawList().AddRect(ImGui.GetItemRectMin(), ImGui.GetItemRectMax(), UiColors.ForegroundFull.Fade(0.1f));
-            
-            if (ImGui.IsItemDeactivated() && ImGui.IsKeyPressed((ImGuiKey)Key.Return))
-            {
-                shouldClose = true;
-            }
-            
-            // Label Placeholder
-            if (string.IsNullOrEmpty(annotation.Label))
-            {
-                ImGui.GetWindowDrawList().AddText(Fonts.FontNormal,
-                                                  Fonts.FontNormal.FontSize,
-                                                  ImGui.GetItemRectMin() + new Vector2(3, 4),
-                                                  UiColors.ForegroundFull.Fade(0.3f),
-                                                  "Label...");
-            }
-            
+            ImGui.GetWindowDrawList().AddText(Fonts.FontNormal, Fonts.FontNormal.FontSize, ImGui.GetItemRectMin() + new Vector2(3, 4), UiColors.ForegroundFull.Fade(0.3f), "Label...");
         }
 
         ImGui.SetCursorScreenPos(new Vector2(ImGui.GetItemRectMin().X, ImGui.GetItemRectMax().Y));
 
-        // Edit description
+        // --- Title/description editing UI ---
+        ImGui.InputTextMultiline("##renameAnnotation", ref _titleBuffer, 1024, screenArea.GetSize() - new Vector2(0, ImGui.GetItemRectSize().Y) - Vector2.One * 3, ImGuiInputTextFlags.AutoSelectAll);
+        // Draw placeholder if title is empty
+        if (string.IsNullOrEmpty(_titleBuffer))
         {
-            var text = annotation.Title;
-
-            // Note: As of imgui 1.89 AutoSelectAll might not be supported for InputTextMultiline
-            ImGui.InputTextMultiline("##renameAnnotation", 
-                                     ref text, 
-                                     256,
-                                     screenArea.GetSize() - new Vector2(0, ImGui.GetItemRectSize().Y) - Vector2.One *3,
-                                     ImGuiInputTextFlags.AutoSelectAll);
-            if (!ImGui.IsItemDeactivated())
-                annotation.Title = text;
-
-            // Placeholder
-            if (string.IsNullOrEmpty(annotation.Title))
-            {
-                ImGui.GetWindowDrawList().AddText(Fonts.FontNormal,
-                                                  Fonts.FontNormal.FontSize,
-                                                  ImGui.GetItemRectMin() + new Vector2(7, 7),
-                                                  UiColors.ForegroundFull.Fade(0.3f),
-                                                  "Description...");
-            }
+            ImGui.GetWindowDrawList().AddText(Fonts.FontNormal, Fonts.FontNormal.FontSize, ImGui.GetItemRectMin() + new Vector2(7, 7), UiColors.ForegroundFull.Fade(0.3f), "Description...");
         }
+
+        // Update annotation with buffer values
+        annotation.Label = _labelBuffer;
+        annotation.Title = _titleBuffer;
+
+        // Wait for user to finish editing before closing
         if (justOpened || _changeAnnotationTextCommand == null)
             return;
 
+        // Detect if the user clicked outside, pressed Esc, or deactivated the item
         var clickedOutside = ImGui.IsMouseClicked(ImGuiMouseButton.Left) && !screenArea.Contains(ImGui.GetMousePos());
-        
         shouldClose |= ImGui.IsItemDeactivated() || ImGui.IsKeyPressed((ImGuiKey)Key.Esc) || clickedOutside;
         if (!shouldClose)
             return;
 
+        // Reset state and close dialog
         _focusedAnnotationId = Guid.Empty;
-        _changeAnnotationTextCommand.NewText = annotation.Title;
         context.ActiveAnnotationId = Guid.Empty;
 
-        UndoRedoStack.AddAndExecute(_changeAnnotationTextCommand);
+        // Only execute command if text changed and not cancelled
+        if (_titleBuffer != _originalTitle && !ImGui.IsKeyPressed((ImGuiKey)Key.Esc))
+        {
+            _changeAnnotationTextCommand.NewText = annotation.Title;
+            UndoRedoStack.AddAndExecute(_changeAnnotationTextCommand);
+        }
+
         context.StateMachine.SetState(GraphStates.Default, context);
     }
-
-    private static Guid _focusedAnnotationId;
-    private static ChangeAnnotationTextCommand? _changeAnnotationTextCommand;
 }

--- a/Editor/Gui/MagGraph/Interaction/KeyboardActions.cs
+++ b/Editor/Gui/MagGraph/Interaction/KeyboardActions.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using T3.Editor.Gui.Interaction;
 using T3.Editor.Gui.Interaction.Keyboard;
 using T3.Editor.Gui.MagGraph.Model;
@@ -103,13 +103,21 @@ internal static class KeyboardActions
 
         if (UserActions.CopyToClipboard.Triggered())
         {
-            NodeActions.CopySelectedNodesToClipboard(context.Selector, compositionOp);
+            // Prevent node graph copy if a text input is active (e.g., annotation description)
+            if (!ImGuiNET.ImGui.IsAnyItemActive())
+            {
+                NodeActions.CopySelectedNodesToClipboard(context.Selector, compositionOp);
+            }
         }
 
         if (!T3Ui.IsCurrentlySaving && UserActions.PasteFromClipboard.Triggered())
         {
-            NodeActions.PasteClipboard(context.Selector, context.View, compositionOp);
-            context.Layout.FlagStructureAsChanged();
+            // Prevent node graph paste if a text input is active (e.g., annotation description)
+            if (!ImGuiNET.ImGui.IsAnyItemActive())
+            {
+                NodeActions.PasteClipboard(context.Selector, context.View, compositionOp);
+                context.Layout.FlagStructureAsChanged();
+            }
         }
 
         if (!T3Ui.IsCurrentlySaving && UserActions.PasteValues.Triggered())


### PR DESCRIPTION
Allows copy/pasting to and from annotations

KeyboardActions: 
- Prevent node graph copy/paste if a text input is active (e.g., annotation description)

AnnotationRenaming:
- Added copy/paste ability
- Uses exponential text buffer, allows for pasting large amounts of text (Like node graph json) while keeping overhead as low as possible. Minimum buffer is 256 chars as before.
