### PR TITLE
[EaseKeys] enhancements

### DIFF
--- a/Operators/Lib/numbers/float/process/EaseKeys.cs
+++ b/Operators/Lib/numbers/float/process/EaseKeys.cs
@@ -38,9 +38,12 @@ internal sealed class EaseKeys : Instance<EaseKeys>
 
         _lastEvalTime = currentTime;
 
-        var duration = 0.0001f;
+        float duration;
 
-        if (TryFindClosestKeys(currentTime, out var nearestKeys))
+        if (
+            TryFindClosestKeys(currentTime, out var nearestKeys)
+            && nearestKeys.Item1.OutType != VDefinition.Interpolation.Constant
+        )
         {
             var (previousKey, nextKey) = nearestKeys;
             _startTime = previousKey.U;

--- a/Operators/Lib/numbers/float/process/EaseKeys.t3ui
+++ b/Operators/Lib/numbers/float/process/EaseKeys.t3ui
@@ -1,6 +1,6 @@
 {
   "Id": "02aed181-4bf1-48f8-ac2a-93d66c170c0c"/*EaseKeys*/,
-  "Description": "This operator creates smooth, ease-in-out transitions by overriding the easing of keyframes. Customize the transition style with options like cubic, exponential, or back easing, or choose a linear fallback for a simple interpolation. \n[EaseVec2Keys] [EaseVec3Keys]",
+  "Description": "This operator creates smooth, ease-in-out transitions by overriding the easing of keyframes. Customize the transition style with options like cubic, exponential, or back easing, or choose a linear fallback for a simple interpolation. \nConstant interpolation can be achieved by setting the keyframe type to Constant.[EaseVec2Keys] [EaseVec3Keys]",
   "InputUis": [
     {
       "InputId": "73c822ca-560c-4e86-b4ff-0ae722d7a371"/*Value*/,

--- a/Operators/Lib/numbers/vec2/process/EaseVec2Keys.cs
+++ b/Operators/Lib/numbers/vec2/process/EaseVec2Keys.cs
@@ -39,9 +39,12 @@ internal sealed class EaseVec2Keys : Instance<EaseVec2Keys>
             var curve = curves[i];
             _keyframes = curve.GetVDefinitions().ToList();
             _lastEvalTime = currentTime;
-            var duration = 0.0001f;
+            float duration;
 
-            if (TryFindClosestKeys(currentTime, curve, out var nearestKeys))
+            if (
+                TryFindClosestKeys(currentTime, curve, out var nearestKeys)
+                && nearestKeys.Item1.OutType != VDefinition.Interpolation.Constant
+            )
             {
                 var (previousKey, nextKey) = nearestKeys;
                 _startTime[i] = (float)previousKey.U;

--- a/Operators/Lib/numbers/vec3/process/EaseVec3Keys.cs
+++ b/Operators/Lib/numbers/vec3/process/EaseVec3Keys.cs
@@ -38,9 +38,12 @@ internal sealed class EaseVec3Keys : Instance<EaseVec3Keys>
             var curve = curves[i];
             _keyframes = curve.GetVDefinitions().ToList();
             _lastEvalTime = currentTime;
-            var duration = 0.0001f;
+            float duration;
 
-            if (TryFindClosestKeys(currentTime, curve, out var nearestKeys))
+            if (
+                TryFindClosestKeys(currentTime, curve, out var nearestKeys)
+                && nearestKeys.Item1.OutType != VDefinition.Interpolation.Constant
+            )
             {
                 var (previousKey, nextKey) = nearestKeys;
                 _startTime[i] = (float)previousKey.U;


### PR DESCRIPTION
- Fixes the output value of [EaseKeys] operators when the playhead is outside the keyframe range, especially when seeking outside that range (i forgot an early return there, so it still tried to interpolate the wrong value with wrong data).
- Makes it so Constant easing keyframes override the [EaseKeys] easing