### PR TITLE
Add: Selected symbol locator in library

### DIFF
--- a/Editor/Gui/Windows/SymbolLib/SymbolLibrary.cs
+++ b/Editor/Gui/Windows/SymbolLib/SymbolLibrary.cs
@@ -284,9 +284,9 @@ internal sealed class SymbolLibrary : Window
                 Icons.DrawIconOnLastItem(Icon.Aim, color);
 
                 // Optionally, scroll to item if just selected
-                if (fadeProgress < 0.2f)
+                if (_expandToSymbolTriggered && selectedSymbolId.HasValue)
                 {
-                    ImGui.SetScrollHereY(0.5f);
+                    ImGui.SetScrollHereY();
                 }
 
                 // Set expand trigger if clicked


### PR DESCRIPTION
Added a selected operator locator like Asset Browser to Symbol Library

<img width="525" height="332" alt="image" src="https://github.com/user-attachments/assets/a9f2963a-bee8-4b00-b8ed-b2f24506399b" />

<img width="445" height="407" alt="image" src="https://github.com/user-attachments/assets/8364798b-f627-427d-99dc-c5417eb2d26a" />
