### PR TITLE
Adding more inputs for CustomPixelShader + example

### DIFF
--- a/Operators/Lib/image/use/CustomPixelShader.cs
+++ b/Operators/Lib/image/use/CustomPixelShader.cs
@@ -7,6 +7,9 @@ internal sealed class CustomPixelShader : Instance<CustomPixelShader>
         [Input(Guid = "5f90f885-0ccc-4014-a921-dc710257835a")]
         public readonly InputSlot<T3.Core.DataTypes.Texture2D> FxTexture = new InputSlot<T3.Core.DataTypes.Texture2D>();
 
+        [Input(Guid = "e63cf24c-0e01-47d4-9532-18261310315e")]
+        public readonly InputSlot<T3.Core.DataTypes.Texture2D> FxTexture2 = new InputSlot<T3.Core.DataTypes.Texture2D>();
+
         [Input(Guid = "8c3ffefe-8721-4dde-b252-22eb8be02d3f")]
         public readonly InputSlot<string> ShaderCode = new InputSlot<string>();
 
@@ -28,11 +31,29 @@ internal sealed class CustomPixelShader : Instance<CustomPixelShader>
         [Input(Guid = "83e06d04-02bd-40cc-8666-d5dd62a9e63e")]
         public readonly InputSlot<T3.Core.DataTypes.Vector.Int2> Resolution = new InputSlot<T3.Core.DataTypes.Vector.Int2>();
 
-        [Input(Guid = "fb8d51fe-b4c2-452a-9e53-b649aed92bd7")]
-        public readonly InputSlot<bool> IgnoreTemplate = new InputSlot<bool>();
+        [Input(Guid = "e0d05b9c-d433-4b9d-8e70-db2f7993d628")]
+        public readonly InputSlot<SharpDX.DXGI.Format> TextureFormat = new InputSlot<SharpDX.DXGI.Format>();
+
+        [Input(Guid = "92fdfa08-e7da-4a71-9145-277b74c93729")]
+        public readonly InputSlot<bool> GenerateMips = new InputSlot<bool>();
+
+        [Input(Guid = "a965b7d3-c78f-4da7-ae70-c461cc9b173c")]
+        public readonly InputSlot<bool> Clear = new InputSlot<bool>();
 
         [Input(Guid = "c9a801ec-13fb-4ad4-b0cd-d125b5db500a")]
         public readonly InputSlot<string> AdditionalCode = new InputSlot<string>();
+
+        [Input(Guid = "fb8d51fe-b4c2-452a-9e53-b649aed92bd7")]
+        public readonly InputSlot<bool> IgnoreTemplate = new InputSlot<bool>();
+
+        [Input(Guid = "b898c5a9-1c4b-4958-a7c1-01c27da10f6a")]
+        public readonly MultiInputSlot<SharpDX.Direct3D11.ShaderResourceView> ShaderResources = new MultiInputSlot<SharpDX.Direct3D11.ShaderResourceView>();
+
+        [Input(Guid = "2dc4d202-2ee5-4d4d-b1b2-234a0b21ab94")]
+        public readonly MultiInputSlot<SharpDX.Direct3D11.Buffer> ConstantBuffers = new MultiInputSlot<SharpDX.Direct3D11.Buffer>();
+
+        [Input(Guid = "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12")]
+        public readonly MultiInputSlot<SharpDX.Direct3D11.SamplerState> CustomSampler = new MultiInputSlot<SharpDX.Direct3D11.SamplerState>();
 
     [Output(Guid = "12fcfd9e-1c2f-46fc-b570-83b93ec7d101")]
     public readonly Slot<Texture2D> TextureOutput = new();

--- a/Operators/Lib/image/use/CustomPixelShader.t3
+++ b/Operators/Lib/image/use/CustomPixelShader.t3
@@ -2,6 +2,10 @@
   "Id": "46daab0e-e957-413e-826c-0699569d0e07"/*CustomPixelShader*/,
   "Inputs": [
     {
+      "Id": "2dc4d202-2ee5-4d4d-b1b2-234a0b21ab94"/*ConstantBuffers*/,
+      "DefaultValue": null
+    },
+    {
       "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
       "DefaultValue": 0.0
     },
@@ -32,8 +36,24 @@
       "DefaultValue": "uv+=Center;\nc=  float4(uv,0,1);\nc*= Image.Sample(Sampler, uv);"
     },
     {
+      "Id": "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12"/*CustomSampler*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "92fdfa08-e7da-4a71-9145-277b74c93729"/*GenerateMips*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "a965b7d3-c78f-4da7-ae70-c461cc9b173c"/*Clear*/,
+      "DefaultValue": true
+    },
+    {
       "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
       "DefaultValue": 0.0
+    },
+    {
+      "Id": "b898c5a9-1c4b-4958-a7c1-01c27da10f6a"/*ShaderResources*/,
+      "DefaultValue": null
     },
     {
       "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
@@ -42,6 +62,14 @@
     {
       "Id": "db522fd4-5cfc-49f6-9983-02ec0dd6090a"/*D*/,
       "DefaultValue": 0.0
+    },
+    {
+      "Id": "e0d05b9c-d433-4b9d-8e70-db2f7993d628"/*TextureFormat*/,
+      "DefaultValue": "R16G16B16A16_Float"
+    },
+    {
+      "Id": "e63cf24c-0e01-47d4-9532-18261310315e"/*FxTexture2*/,
+      "DefaultValue": null
     },
     {
       "Id": "fb8d51fe-b4c2-452a-9e53-b649aed92bd7"/*IgnoreTemplate*/,
@@ -68,6 +96,18 @@
           "Id": "873ad863-dec6-4b4b-9d81-89d5fa11beec"/*IndependentBlendEnable*/,
           "Type": "System.Boolean",
           "Value": false
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "0bcbfeed-5bab-4a31-9508-e34091b247ae"/*CombineStrings*/,
+      "SymbolId": "48ab9824-76ca-4238-800f-9cf95311e6c0",
+      "InputValues": [
+        {
+          "Id": "c832ba89-f4ae-4c47-b62b-52da52a09556"/*Separator*/,
+          "Type": "System.String",
+          "Value": "\\n"
         }
       ],
       "Outputs": []
@@ -104,6 +144,12 @@
     {
       "Id": "18c31c73-446a-4d56-9e84-70d93618a312"/*Vector2Components*/,
       "SymbolId": "0946c48b-85d8-4072-8f21-11d17cc6f6cf",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "237490cb-db7b-4154-a672-35ab594b3e93"/*SrvFromTexture2d*/,
+      "SymbolId": "c2078514-cf1d-439c-a732-0d7b31b5084a",
       "InputValues": [],
       "Outputs": []
     },
@@ -188,7 +234,55 @@
         {
           "Id": "ceeae47b-d792-471d-a825-49e22749b7b9"/*InputString*/,
           "Type": "System.String",
-          "Value": "cbuffer ParamConstants : register(b0)\n{\n    float2 Center;\n    float A;\n    float B;\n    float C;\n    float D;\n\n}\n\ncbuffer Resolution : register(b1)\n{\n    float TargetWidth;\n    float TargetHeight;\n}\n\nstruct vsOutput\n{\n    float4 position : SV_POSITION;\n    float2 texCoord : TEXCOORD;\n};\n\nTexture2D<float4> Image : register(t0);\nsampler Sampler : register(s0);\n\n\nfloat4 psMain(vsOutput input) : SV_TARGET\n{\n    float width, height;\n    Image.GetDimensions(width, height);\n    float4 c=float4(1,1,0,1);\n\n    float2 uv = input.texCoord;\n    \n    #include \"snippet\"\n    return c;\n}"
+          "Value": "cbuffer ParamConstants : register(b0)\n{\n    float2 Center;\n    float A;\n    float B;\n    float C;\n    float D;\n\n}\n\ncbuffer Resolution : register(b1)\n{\n    float TargetWidth;\n    float TargetHeight;\n}\n\nstruct vsOutput\n{\n    float4 position : SV_POSITION;\n    float2 texCoord : TEXCOORD;\n};\n\nTexture2D<float4> Image : register(t0);\nTexture2D<float4> Image2 : register(t1);\nsampler Sampler : register(s0);\nsampler CustomSampler : register(s1);\n\n#include \"defs\"\n\nfloat4 psMain(vsOutput input) : SV_TARGET\n{\n    float width, height;\n    Image.GetDimensions(width, height);\n    float4 c=float4(1,1,0,1);\n   \n    float2 uv = input.texCoord;\n    int2 TargetSize=int2(TargetWidth,TargetHeight);\n    int2 PixelCoord=int2(round(uv*TargetSize-.25));\n    \n    #include \"snippet\"\n\n    return c;\n}"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "3b71d7ec-4c5b-4243-8d78-057e7268191b"/*BlendEnabled*/,
+      "SymbolId": "ed0f5188-8888-453e-8db4-20d87d18e9f4",
+      "Name": "BlendEnabled",
+      "InputValues": [
+        {
+          "Id": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"/*BoolValue*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "3b7326be-7663-474e-b1fa-5246557cfc32"/*BoolToInt*/,
+      "SymbolId": "cd43942a-887e-4e34-bc54-0c2e5e8bc2af",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "4c7fe29c-09f1-496b-8ca1-a18d44e13c0f"/*SearchAndReplace*/,
+      "SymbolId": "b7910fc6-c3b2-4daf-93cd-010dcfe22a57",
+      "InputValues": [
+        {
+          "Id": "4fe3f641-1c36-4970-be71-dafb5632fb53"/*SearchPattern*/,
+          "Type": "System.String",
+          "Value": "#include \"defs\""
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "594b32cf-aaad-4785-90ad-6bfe9425f8ab"/*BlendState*/,
+      "SymbolId": "064ca51f-47ab-4cb7-95f2-e537b68e137e",
+      "InputValues": [
+        {
+          "Id": "3ca79807-00c9-471a-ac44-525a05740fed"/*AlphaToCoverageEnable*/,
+          "Type": "System.Boolean",
+          "Value": false
+        },
+        {
+          "Id": "873ad863-dec6-4b4b-9d81-89d5fa11beec"/*IndependentBlendEnable*/,
+          "Type": "System.Boolean",
+          "Value": false
         }
       ],
       "Outputs": []
@@ -246,7 +340,7 @@
         {
           "Id": "7f535169-8f65-4186-866d-59c2b89d7da2"/*BlendEnabled*/,
           "Type": "System.Boolean",
-          "Value": true
+          "Value": false
         },
         {
           "Id": "8dc53fe4-79bb-43e4-9d4a-4e06f9a3214c"/*DestinationBlend*/,
@@ -262,9 +356,26 @@
       "Outputs": []
     },
     {
+      "Id": "82c2bf9e-d9b7-46b4-bb81-5a08f73a400c"/*CombineStrings*/,
+      "SymbolId": "48ab9824-76ca-4238-800f-9cf95311e6c0",
+      "InputValues": [
+        {
+          "Id": "c832ba89-f4ae-4c47-b62b-52da52a09556"/*Separator*/,
+          "Type": "System.String",
+          "Value": "\\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
       "Id": "8435d04a-724f-4886-97ee-480691ce219d"/*RenderTarget*/,
       "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
       "InputValues": [
+        {
+          "Id": "6ea4f801-ff52-4266-a41f-b9ef02c68510"/*WithDepthBuffer*/,
+          "Type": "System.Boolean",
+          "Value": false
+        },
         {
           "Id": "8bb4a4e5-0c88-4d99-a5b2-2c9e22bd301f"/*ClearColor*/,
           "Type": "System.Numerics.Vector4",
@@ -334,6 +445,43 @@
       "Outputs": []
     },
     {
+      "Id": "a434f627-446f-4fc5-8eec-5027da717681"/*String*/,
+      "SymbolId": "5880cbc3-a541-4484-a06a-0e6f77cdbe8e",
+      "InputValues": [
+        {
+          "Id": "ceeae47b-d792-471d-a825-49e22749b7b9"/*InputString*/,
+          "Type": "System.String",
+          "Value": "//additional defines"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "ad890372-987f-46bc-bc2b-62a1f6c2cba2"/*String*/,
+      "SymbolId": "5880cbc3-a541-4484-a06a-0e6f77cdbe8e",
+      "InputValues": [
+        {
+          "Id": "ceeae47b-d792-471d-a825-49e22749b7b9"/*InputString*/,
+          "Type": "System.String",
+          "Value": "//code snippet"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "bb40096e-696c-43e9-af55-40ba0451bfb4"/*Clear*/,
+      "SymbolId": "ed0f5188-8888-453e-8db4-20d87d18e9f4",
+      "Name": "Clear",
+      "InputValues": [
+        {
+          "Id": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"/*BoolValue*/,
+          "Type": "System.Boolean",
+          "Value": false
+        }
+      ],
+      "Outputs": []
+    },
+    {
       "Id": "c4ab0bb6-bc1a-405a-9730-f89fa9618962"/*FloatsToBuffer*/,
       "SymbolId": "724da755-2d0c-42ab-8335-8c88ec5fb078",
       "InputValues": [],
@@ -346,9 +494,75 @@
       "Outputs": []
     },
     {
+      "Id": "c7bcc51b-7a42-43eb-9391-4c25a26b9478"/*RenderTargetBlendDescription*/,
+      "SymbolId": "38ee7546-8d7d-463c-aeea-e482d7ca3f30",
+      "InputValues": [
+        {
+          "Id": "2632af70-5a05-429c-8123-fe280adea655"/*SourceAlphaBlend*/,
+          "Type": "SharpDX.Direct3D11.BlendOption",
+          "Value": "One"
+        },
+        {
+          "Id": "56c398ce-fe71-47eb-a33f-11eec8f82e79"/*SourceBlend*/,
+          "Type": "SharpDX.Direct3D11.BlendOption",
+          "Value": "SourceAlpha"
+        },
+        {
+          "Id": "7f535169-8f65-4186-866d-59c2b89d7da2"/*BlendEnabled*/,
+          "Type": "System.Boolean",
+          "Value": false
+        },
+        {
+          "Id": "8dc53fe4-79bb-43e4-9d4a-4e06f9a3214c"/*DestinationBlend*/,
+          "Type": "SharpDX.Direct3D11.BlendOption",
+          "Value": "InverseSourceAlpha"
+        },
+        {
+          "Id": "acc5550b-18ed-4dba-8e69-d5228e2ad850"/*DestinationAlphaBlend*/,
+          "Type": "SharpDX.Direct3D11.BlendOption",
+          "Value": "InverseSourceAlpha"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c7f79a6d-f308-4368-9319-f58bb24b379e"/*UseFallbackTexture*/,
+      "SymbolId": "b470fdf9-ac0b-4eb9-9600-453b8c094e3f",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "cda97bdc-de01-4701-90f9-64bbd19108cb"/*Switch*/,
+      "SymbolId": "e64f95e4-c045-400f-98ca-7c020ad46174",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
       "Id": "dc1ea202-785f-4a4b-84ae-d89792b9448b"/*PixelShaderStage*/,
       "SymbolId": "75306997-4329-44e9-a17a-050dae532182",
       "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "dfaabd73-b111-4eb6-a273-3a2db3cd3833"/*OutputMergerStage*/,
+      "SymbolId": "5efaf208-ba62-42ce-b3df-059b37fc1382",
+      "InputValues": [
+        {
+          "Id": "03166157-1e18-4513-8af5-398c6f4fcb1e"/*BlendSampleMask*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "ccee2ec3-586f-4396-8b20-cc99484e1b64"/*BlendFactor*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 1.0,
+            "Z": 1.0,
+            "W": 0.984
+          }
+        }
+      ],
       "Outputs": []
     },
     {
@@ -366,6 +580,12 @@
           "Value": "vsMain"
         }
       ],
+      "Outputs": []
+    },
+    {
+      "Id": "e45d926c-4208-4305-91da-2fe427be6dc1"/*Not*/,
+      "SymbolId": "51648ecd-05ee-40b3-b562-8518ada70918",
+      "InputValues": [],
       "Outputs": []
     },
     {
@@ -396,6 +616,19 @@
           "DirtyFlagTrigger": "Always"
         }
       ]
+    },
+    {
+      "Id": "f8db1d5e-bf8f-4d55-89ea-ded2def3e1d7"/*GenerateMips*/,
+      "SymbolId": "ed0f5188-8888-453e-8db4-20d87d18e9f4",
+      "Name": "GenerateMips",
+      "InputValues": [
+        {
+          "Id": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"/*BoolValue*/,
+          "Type": "System.Boolean",
+          "Value": false
+        }
+      ],
+      "Outputs": []
     }
   ],
   "Connections": [
@@ -406,8 +639,8 @@
       "TargetSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101"
     },
     {
-      "SourceParentOrChildId": "13e787b4-db91-4e45-8013-5c34250bc731",
-      "SourceSlotId": "e47bf25e-351a-44e6-84c6-ad3abc93531a",
+      "SourceParentOrChildId": "59c9fcc2-5664-4db9-9481-12831708a5d9",
+      "SourceSlotId": "74104eb6-dfc2-4ad2-9600-91c5a33855d4",
       "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "TargetSlotId": "163afb2e-2c9d-46b6-8959-a7736912d3f5"
     },
@@ -424,14 +657,26 @@
       "TargetSlotId": "63d0e4e8-fa00-4059-a11b-6a31e66757dc"
     },
     {
+      "SourceParentOrChildId": "a434f627-446f-4fc5-8eec-5027da717681",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "0bcbfeed-5bab-4a31-9508-e34091b247ae",
+      "TargetSlotId": "b5e72715-9339-484f-b197-5a28cd823798"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a",
+      "TargetParentOrChildId": "0bcbfeed-5bab-4a31-9508-e34091b247ae",
+      "TargetSlotId": "b5e72715-9339-484f-b197-5a28cd823798"
+    },
+    {
       "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
       "SourceSlotId": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a",
       "TargetParentOrChildId": "13e787b4-db91-4e45-8013-5c34250bc731",
       "TargetSlotId": "b5e72715-9339-484f-b197-5a28cd823798"
     },
     {
-      "SourceParentOrChildId": "59c9fcc2-5664-4db9-9481-12831708a5d9",
-      "SourceSlotId": "74104eb6-dfc2-4ad2-9600-91c5a33855d4",
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "8c3ffefe-8721-4dde-b252-22eb8be02d3f",
       "TargetParentOrChildId": "13e787b4-db91-4e45-8013-5c34250bc731",
       "TargetSlotId": "b5e72715-9339-484f-b197-5a28cd823798"
     },
@@ -442,10 +687,46 @@
       "TargetSlotId": "36f14238-5bb8-4521-9533-f4d1e8fb802b"
     },
     {
+      "SourceParentOrChildId": "c7f79a6d-f308-4368-9319-f58bb24b379e",
+      "SourceSlotId": "778f4eac-24ef-4e93-b864-39f150ab6cb2",
+      "TargetParentOrChildId": "237490cb-db7b-4154-a672-35ab594b3e93",
+      "TargetSlotId": "d5afa102-2f88-431e-9cd4-af91e41f88f6"
+    },
+    {
       "SourceParentOrChildId": "05cc3af5-2775-4b08-95d7-e68b4f9e4274",
       "SourceSlotId": "6ef6c44b-ee22-4c64-9910-4f7595c41897",
       "TargetParentOrChildId": "293647dd-9810-42e7-85da-d55736d464ed",
       "TargetSlotId": "e0bc9cf8-42c8-4632-b958-7a96f6d03ba2"
+    },
+    {
+      "SourceParentOrChildId": "e45d926c-4208-4305-91da-2fe427be6dc1",
+      "SourceSlotId": "0274f62a-b3a2-49e3-a486-043ee71f366b",
+      "TargetParentOrChildId": "3b71d7ec-4c5b-4243-8d78-057e7268191b",
+      "TargetSlotId": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "a965b7d3-c78f-4da7-ae70-c461cc9b173c",
+      "TargetParentOrChildId": "3b7326be-7663-474e-b1fa-5246557cfc32",
+      "TargetSlotId": "c644165f-3901-4dbf-8091-05f958e668e5"
+    },
+    {
+      "SourceParentOrChildId": "3b4a7379-fc18-4eea-883e-ffc5113a39fa",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "4c7fe29c-09f1-496b-8ca1-a18d44e13c0f",
+      "TargetSlotId": "3ca66cbd-a16a-479c-b858-84732e5023ad"
+    },
+    {
+      "SourceParentOrChildId": "0bcbfeed-5bab-4a31-9508-e34091b247ae",
+      "SourceSlotId": "e47bf25e-351a-44e6-84c6-ad3abc93531a",
+      "TargetParentOrChildId": "4c7fe29c-09f1-496b-8ca1-a18d44e13c0f",
+      "TargetSlotId": "de8297ae-c7d8-414a-8825-d0ff9c2e3d78"
+    },
+    {
+      "SourceParentOrChildId": "c7bcc51b-7a42-43eb-9391-4c25a26b9478",
+      "SourceSlotId": "228e1dc2-944e-4235-bf2d-2eb3f895858c",
+      "TargetParentOrChildId": "594b32cf-aaad-4785-90ad-6bfe9425f8ab",
+      "TargetSlotId": "63d0e4e8-fa00-4059-a11b-6a31e66757dc"
     },
     {
       "SourceParentOrChildId": "ece44113-bc25-4b4a-b8f4-23f6037d1ad0",
@@ -454,8 +735,8 @@
       "TargetSlotId": "202ce6d5-ee5a-41c7-bd04-4c1490f3ea9c"
     },
     {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "8c3ffefe-8721-4dde-b252-22eb8be02d3f",
+      "SourceParentOrChildId": "13e787b4-db91-4e45-8013-5c34250bc731",
+      "SourceSlotId": "e47bf25e-351a-44e6-84c6-ad3abc93531a",
       "TargetParentOrChildId": "59c9fcc2-5664-4db9-9481-12831708a5d9",
       "TargetSlotId": "202ce6d5-ee5a-41c7-bd04-4c1490f3ea9c"
     },
@@ -472,8 +753,8 @@
       "TargetSlotId": "d5afa102-2f88-431e-9cd4-af91e41f88f6"
     },
     {
-      "SourceParentOrChildId": "13e787b4-db91-4e45-8013-5c34250bc731",
-      "SourceSlotId": "e47bf25e-351a-44e6-84c6-ad3abc93531a",
+      "SourceParentOrChildId": "59c9fcc2-5664-4db9-9481-12831708a5d9",
+      "SourceSlotId": "74104eb6-dfc2-4ad2-9600-91c5a33855d4",
       "TargetParentOrChildId": "5e6d5cb9-df8f-494d-b50e-31499b257f34",
       "TargetSlotId": "a192e8cc-2874-4f02-bbf1-4622e99666e1"
     },
@@ -490,6 +771,18 @@
       "TargetSlotId": "5c76dc8d-3a28-4b93-b3a0-e008c1ff14e9"
     },
     {
+      "SourceParentOrChildId": "ad890372-987f-46bc-bc2b-62a1f6c2cba2",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "82c2bf9e-d9b7-46b4-bb81-5a08f73a400c",
+      "TargetSlotId": "b5e72715-9339-484f-b197-5a28cd823798"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "8c3ffefe-8721-4dde-b252-22eb8be02d3f",
+      "TargetParentOrChildId": "82c2bf9e-d9b7-46b4-bb81-5a08f73a400c",
+      "TargetSlotId": "b5e72715-9339-484f-b197-5a28cd823798"
+    },
+    {
       "SourceParentOrChildId": "efd3aeb9-2f4a-4297-a015-01e78f9521cb",
       "SourceSlotId": "be16d5d3-4d21-4d5a-9e4c-c7b2779b6bdc",
       "TargetParentOrChildId": "8435d04a-724f-4886-97ee-480691ce219d",
@@ -500,6 +793,24 @@
       "SourceSlotId": "e81c99ce-fcee-4e7c-a1c7-0aa3b352b7e1",
       "TargetParentOrChildId": "8435d04a-724f-4886-97ee-480691ce219d",
       "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    },
+    {
+      "SourceParentOrChildId": "bb40096e-696c-43e9-af55-40ba0451bfb4",
+      "SourceSlotId": "97a91f72-1e40-412c-911e-70b142e16925",
+      "TargetParentOrChildId": "8435d04a-724f-4886-97ee-480691ce219d",
+      "TargetSlotId": "aacafc4d-f47f-4893-9a6e-98db306a8901"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "e0d05b9c-d433-4b9d-8e70-db2f7993d628",
+      "TargetParentOrChildId": "8435d04a-724f-4886-97ee-480691ce219d",
+      "TargetSlotId": "ec46bef4-8dce-4eb4-bfe8-e35a5ac416ec"
+    },
+    {
+      "SourceParentOrChildId": "f8db1d5e-bf8f-4d55-89ea-ded2def3e1d7",
+      "SourceSlotId": "97a91f72-1e40-412c-911e-70b142e16925",
+      "TargetParentOrChildId": "8435d04a-724f-4886-97ee-480691ce219d",
+      "TargetSlotId": "f0cf3325-4967-4419-9beb-036cd6dbfd6a"
     },
     {
       "SourceParentOrChildId": "e2cd7180-4b98-46a0-b5d3-c6c769674434",
@@ -530,6 +841,12 @@
       "SourceSlotId": "fb8d51fe-b4c2-452a-9e53-b649aed92bd7",
       "TargetParentOrChildId": "90a1c68c-dad1-4369-8bd0-5e983ef8d6d9",
       "TargetSlotId": "c644165f-3901-4dbf-8091-05f958e668e5"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "a965b7d3-c78f-4da7-ae70-c461cc9b173c",
+      "TargetParentOrChildId": "bb40096e-696c-43e9-af55-40ba0451bfb4",
+      "TargetSlotId": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"
     },
     {
       "SourceParentOrChildId": "18c31c73-446a-4d56-9e84-70d93618a312",
@@ -592,7 +909,7 @@
       "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
     },
     {
-      "SourceParentOrChildId": "293647dd-9810-42e7-85da-d55736d464ed",
+      "SourceParentOrChildId": "dfaabd73-b111-4eb6-a273-3a2db3cd3833",
       "SourceSlotId": "cee8c3f0-64ea-4e4d-b967-ec7e3688dd03",
       "TargetParentOrChildId": "c6acc8b3-9278-41f8-8c15-1c89dfa29d4a",
       "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
@@ -604,6 +921,42 @@
       "TargetSlotId": "5d73ebe6-9aa0-471a-ae6b-3f5bfd5a0f9c"
     },
     {
+      "SourceParentOrChildId": "3b71d7ec-4c5b-4243-8d78-057e7268191b",
+      "SourceSlotId": "97a91f72-1e40-412c-911e-70b142e16925",
+      "TargetParentOrChildId": "c7bcc51b-7a42-43eb-9391-4c25a26b9478",
+      "TargetSlotId": "7f535169-8f65-4186-866d-59c2b89d7da2"
+    },
+    {
+      "SourceParentOrChildId": "2f16d7a1-5339-4072-8cc8-d07c818a2468",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "c7f79a6d-f308-4368-9319-f58bb24b379e",
+      "TargetSlotId": "38b478fa-c431-4dc1-80ef-d6c53c90389e"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "e63cf24c-0e01-47d4-9532-18261310315e",
+      "TargetParentOrChildId": "c7f79a6d-f308-4368-9319-f58bb24b379e",
+      "TargetSlotId": "91bffbba-b815-44d7-8f93-3238376935bf"
+    },
+    {
+      "SourceParentOrChildId": "3b7326be-7663-474e-b1fa-5246557cfc32",
+      "SourceSlotId": "b0cfa6f9-3c3d-4499-b21a-5904d1cb3bd7",
+      "TargetParentOrChildId": "cda97bdc-de01-4701-90f9-64bbd19108cb",
+      "TargetSlotId": "00fd2794-567a-4f9b-a900-c2ebf9760764"
+    },
+    {
+      "SourceParentOrChildId": "293647dd-9810-42e7-85da-d55736d464ed",
+      "SourceSlotId": "cee8c3f0-64ea-4e4d-b967-ec7e3688dd03",
+      "TargetParentOrChildId": "cda97bdc-de01-4701-90f9-64bbd19108cb",
+      "TargetSlotId": "988dd1b5-636d-4a78-9592-2c6601401cc1"
+    },
+    {
+      "SourceParentOrChildId": "dfaabd73-b111-4eb6-a273-3a2db3cd3833",
+      "SourceSlotId": "cee8c3f0-64ea-4e4d-b967-ec7e3688dd03",
+      "TargetParentOrChildId": "cda97bdc-de01-4701-90f9-64bbd19108cb",
+      "TargetSlotId": "988dd1b5-636d-4a78-9592-2c6601401cc1"
+    },
+    {
       "SourceParentOrChildId": "5e6d5cb9-df8f-494d-b50e-31499b257f34",
       "SourceSlotId": "c513f15d-3a7e-4501-b825-ef3e585293c7",
       "TargetParentOrChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b",
@@ -612,6 +965,18 @@
     {
       "SourceParentOrChildId": "5a420498-2b15-4a33-b652-a749055f2397",
       "SourceSlotId": "dc71f39f-3fba-4fc6-b8ef-ce57c82bf78e",
+      "TargetParentOrChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b",
+      "TargetSlotId": "50052906-4691-4a84-a69d-a109044b5300"
+    },
+    {
+      "SourceParentOrChildId": "237490cb-db7b-4154-a672-35ab594b3e93",
+      "SourceSlotId": "dc71f39f-3fba-4fc6-b8ef-ce57c82bf78e",
+      "TargetParentOrChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b",
+      "TargetSlotId": "50052906-4691-4a84-a69d-a109044b5300"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "b898c5a9-1c4b-4958-a7c1-01c27da10f6a",
       "TargetParentOrChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b",
       "TargetSlotId": "50052906-4691-4a84-a69d-a109044b5300"
     },
@@ -628,20 +993,44 @@
       "TargetSlotId": "be02a84b-a666-4119-bb6e-fee1a3df0981"
     },
     {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "2dc4d202-2ee5-4d4d-b1b2-234a0b21ab94",
+      "TargetParentOrChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b",
+      "TargetSlotId": "be02a84b-a666-4119-bb6e-fee1a3df0981"
+    },
+    {
       "SourceParentOrChildId": "25de290b-67e4-49f0-9bc1-ed881ce14976",
       "SourceSlotId": "0e45c596-c80f-4927-941f-e3199401aa10",
       "TargetParentOrChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b",
       "TargetSlotId": "c4e91bc6-1691-4eb4-aed5-dd4cae528149"
     },
     {
-      "SourceParentOrChildId": "3b4a7379-fc18-4eea-883e-ffc5113a39fa",
-      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12",
+      "TargetParentOrChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b",
+      "TargetSlotId": "c4e91bc6-1691-4eb4-aed5-dd4cae528149"
+    },
+    {
+      "SourceParentOrChildId": "594b32cf-aaad-4785-90ad-6bfe9425f8ab",
+      "SourceSlotId": "6ef6c44b-ee22-4c64-9910-4f7595c41897",
+      "TargetParentOrChildId": "dfaabd73-b111-4eb6-a273-3a2db3cd3833",
+      "TargetSlotId": "e0bc9cf8-42c8-4632-b958-7a96f6d03ba2"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "a965b7d3-c78f-4da7-ae70-c461cc9b173c",
+      "TargetParentOrChildId": "e45d926c-4208-4305-91da-2fe427be6dc1",
+      "TargetSlotId": "e5322b67-9c56-4afe-a398-79294858acc0"
+    },
+    {
+      "SourceParentOrChildId": "4c7fe29c-09f1-496b-8ca1-a18d44e13c0f",
+      "SourceSlotId": "15672e8f-c483-432e-8ced-f2bd18c1be67",
       "TargetParentOrChildId": "ece44113-bc25-4b4a-b8f4-23f6037d1ad0",
       "TargetSlotId": "3ca66cbd-a16a-479c-b858-84732e5023ad"
     },
     {
-      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
-      "SourceSlotId": "8c3ffefe-8721-4dde-b252-22eb8be02d3f",
+      "SourceParentOrChildId": "82c2bf9e-d9b7-46b4-bb81-5a08f73a400c",
+      "SourceSlotId": "e47bf25e-351a-44e6-84c6-ad3abc93531a",
       "TargetParentOrChildId": "ece44113-bc25-4b4a-b8f4-23f6037d1ad0",
       "TargetSlotId": "de8297ae-c7d8-414a-8825-d0ff9c2e3d78"
     },
@@ -662,6 +1051,12 @@
       "SourceSlotId": "be16d5d3-4d21-4d5a-9e4c-c7b2779b6bdc",
       "TargetParentOrChildId": "f8d41670-1e0a-4b4a-899b-0e25c118db5f",
       "TargetSlotId": "3bba98bd-2713-4e5b-b082-20b39392ef9b"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "92fdfa08-e7da-4a71-9145-277b74c93729",
+      "TargetParentOrChildId": "f8db1d5e-bf8f-4d55-89ea-ded2def3e1d7",
+      "TargetSlotId": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"
     }
   ]
 }

--- a/Operators/Lib/image/use/CustomPixelShader.t3ui
+++ b/Operators/Lib/image/use/CustomPixelShader.t3ui
@@ -3,6 +3,14 @@
   "Description": "Creates a custom shader from a source parameter. This can be useful for prototyping.\n\nUse \"Ignore Template\" to bring in your entire shader.\n",
   "InputUis": [
     {
+      "InputId": "2dc4d202-2ee5-4d4d-b1b2-234a0b21ab94"/*ConstantBuffers*/,
+      "Position": {
+        "X": 1911.3387,
+        "Y": 785.5515
+      },
+      "Description": "Use FloatsToBuffer or Ints to buffer to pass additional input params, define in AdditionalCode for example:\n\ncbuffer AdditionalIntParams : register(b2)\n{\n    int Index;\n}\ncbuffer AdditionalFloatParams : register(b3)\n{\n    float4 Color;\n}"
+    },
+    {
       "InputId": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
       "Position": {
         "X": -161.39105,
@@ -50,6 +58,29 @@
       "Usage": "Multiline"
     },
     {
+      "InputId": "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12"/*CustomSampler*/,
+      "Position": {
+        "X": 1838.4208,
+        "Y": 1364.0939
+      },
+      "Description": "Use SamplerState node to add custom sampler(s); first sampler input is defined in template as CustomSampler.\nsamplers coming after that will need to be defined in AdditionalCode, for example:\n\nsampler Sampler2 : register(s2);"
+    },
+    {
+      "InputId": "92fdfa08-e7da-4a71-9145-277b74c93729"/*GenerateMips*/,
+      "Position": {
+        "X": 2401.5288,
+        "Y": 1016.59656
+      }
+    },
+    {
+      "InputId": "a965b7d3-c78f-4da7-ae70-c461cc9b173c"/*Clear*/,
+      "Position": {
+        "X": 2353.0198,
+        "Y": 1145.4948
+      },
+      "Description": "Clearing RenderTarget\nsetting it to false also enables blending mode, so that result is blended on top of backbuffer"
+    },
+    {
       "InputId": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
       "Position": {
         "X": -161.39105,
@@ -57,12 +88,20 @@
       }
     },
     {
+      "InputId": "b898c5a9-1c4b-4958-a7c1-01c27da10f6a"/*ShaderResources*/,
+      "Position": {
+        "X": 1911.3387,
+        "Y": 710.5515
+      },
+      "Description": "Use SrvFromTexutre2d for additional texture inputs. They will need to be defined in AdditionalCode, for example:\n\nTexture2D<float4> Image3 : register(t2);"
+    },
+    {
       "InputId": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
       "Position": {
         "X": 99.026855,
         "Y": 715.67053
       },
-      "Usage": "Default"
+      "Usage": "Multiline"
     },
     {
       "InputId": "db522fd4-5cfc-49f6-9983-02ec0dd6090a"/*D*/,
@@ -72,10 +111,24 @@
       }
     },
     {
-      "InputId": "fb8d51fe-b4c2-452a-9e53-b649aed92bd7"/*IgnoreTemplate*/,
+      "InputId": "e0d05b9c-d433-4b9d-8e70-db2f7993d628"/*TextureFormat*/,
+      "Position": {
+        "X": 2505.2117,
+        "Y": 806.4501
+      }
+    },
+    {
+      "InputId": "e63cf24c-0e01-47d4-9532-18261310315e"/*FxTexture2*/,
       "Position": {
         "X": -178.71051,
-        "Y": 1528.4381
+        "Y": 1551.6797
+      }
+    },
+    {
+      "InputId": "fb8d51fe-b4c2-452a-9e53-b649aed92bd7"/*IgnoreTemplate*/,
+      "Position": {
+        "X": -168.46124,
+        "Y": 1784.67
       }
     }
   ],
@@ -95,6 +148,13 @@
       }
     },
     {
+      "ChildId": "0bcbfeed-5bab-4a31-9508-e34091b247ae"/*CombineStrings*/,
+      "Position": {
+        "X": 253.51385,
+        "Y": 334.1512
+      }
+    },
+    {
       "ChildId": "10f6db46-38e3-460f-90a2-21c434534c84"/*PixelShader*/,
       "Position": {
         "X": 1911.3387,
@@ -104,8 +164,8 @@
     {
       "ChildId": "13e787b4-db91-4e45-8013-5c34250bc731"/*CombineStrings*/,
       "Position": {
-        "X": 1101.3688,
-        "Y": 418.37335
+        "X": 688.29767,
+        "Y": 449.28333
       }
     },
     {
@@ -113,6 +173,13 @@
       "Position": {
         "X": -161.39105,
         "Y": 909.246
+      }
+    },
+    {
+      "ChildId": "237490cb-db7b-4154-a672-35ab594b3e93"/*SrvFromTexture2d*/,
+      "Position": {
+        "X": 1656.0803,
+        "Y": 1083.2499
       }
     },
     {
@@ -125,15 +192,15 @@
     {
       "ChildId": "26d9f768-118f-4cfe-bec6-ffd2596d8877"/*Draw*/,
       "Position": {
-        "X": 2231.1826,
-        "Y": 780.1195
+        "X": 2231.1824,
+        "Y": 1052.0929
       }
     },
     {
       "ChildId": "293647dd-9810-42e7-85da-d55736d464ed"/*OutputMergerStage*/,
       "Position": {
-        "X": 2231.1826,
-        "Y": 724.1195
+        "X": 2231.1824,
+        "Y": 941.96967
       }
     },
     {
@@ -158,8 +225,36 @@
         "Y": 366.04495
       },
       "Position": {
-        "X": 54.5506,
-        "Y": 164.08167
+        "X": 173.58493,
+        "Y": 229.05048
+      }
+    },
+    {
+      "ChildId": "3b71d7ec-4c5b-4243-8d78-057e7268191b"/*BlendEnabled*/,
+      "Position": {
+        "X": 1775.2687,
+        "Y": 1203.8466
+      }
+    },
+    {
+      "ChildId": "3b7326be-7663-474e-b1fa-5246557cfc32"/*BoolToInt*/,
+      "Position": {
+        "X": 2549.7866,
+        "Y": 1155.0316
+      }
+    },
+    {
+      "ChildId": "4c7fe29c-09f1-496b-8ca1-a18d44e13c0f"/*SearchAndReplace*/,
+      "Position": {
+        "X": 435.60443,
+        "Y": 229.16037
+      }
+    },
+    {
+      "ChildId": "594b32cf-aaad-4785-90ad-6bfe9425f8ab"/*BlendState*/,
+      "Position": {
+        "X": 2033.0226,
+        "Y": 1048.2683
       }
     },
     {
@@ -205,6 +300,13 @@
       }
     },
     {
+      "ChildId": "82c2bf9e-d9b7-46b4-bb81-5a08f73a400c"/*CombineStrings*/,
+      "Position": {
+        "X": 428.9552,
+        "Y": 438.82837
+      }
+    },
+    {
       "ChildId": "8435d04a-724f-4886-97ee-480691ce219d"/*RenderTarget*/,
       "Position": {
         "X": 2645.2117,
@@ -240,6 +342,27 @@
       }
     },
     {
+      "ChildId": "a434f627-446f-4fc5-8eec-5027da717681"/*String*/,
+      "Position": {
+        "X": 113.513855,
+        "Y": 334.1512
+      }
+    },
+    {
+      "ChildId": "ad890372-987f-46bc-bc2b-62a1f6c2cba2"/*String*/,
+      "Position": {
+        "X": 288.9552,
+        "Y": 438.82837
+      }
+    },
+    {
+      "ChildId": "bb40096e-696c-43e9-af55-40ba0451bfb4"/*Clear*/,
+      "Position": {
+        "X": 2505.2117,
+        "Y": 771.4501
+      }
+    },
+    {
       "ChildId": "c4ab0bb6-bc1a-405a-9730-f89fa9618962"/*FloatsToBuffer*/,
       "Style": "Resizable",
       "Size": {
@@ -264,10 +387,38 @@
       }
     },
     {
+      "ChildId": "c7bcc51b-7a42-43eb-9391-4c25a26b9478"/*RenderTargetBlendDescription*/,
+      "Position": {
+        "X": 1878.809,
+        "Y": 1053.4583
+      }
+    },
+    {
+      "ChildId": "c7f79a6d-f308-4368-9319-f58bb24b379e"/*UseFallbackTexture*/,
+      "Position": {
+        "X": 1516.0803,
+        "Y": 1083.2499
+      }
+    },
+    {
+      "ChildId": "cda97bdc-de01-4701-90f9-64bbd19108cb"/*Switch*/,
+      "Position": {
+        "X": 2570.546,
+        "Y": 942.98785
+      }
+    },
+    {
       "ChildId": "dc1ea202-785f-4a4b-84ae-d89792b9448b"/*PixelShaderStage*/,
       "Position": {
         "X": 2231.1826,
-        "Y": 577.119
+        "Y": 608.9917
+      }
+    },
+    {
+      "ChildId": "dfaabd73-b111-4eb6-a273-3a2db3cd3833"/*OutputMergerStage*/,
+      "Position": {
+        "X": 2231.1824,
+        "Y": 997.11096
       }
     },
     {
@@ -278,10 +429,17 @@
       }
     },
     {
+      "ChildId": "e45d926c-4208-4305-91da-2fe427be6dc1"/*Not*/,
+      "Position": {
+        "X": 2394.8315,
+        "Y": 1294.417
+      }
+    },
+    {
       "ChildId": "ece44113-bc25-4b4a-b8f4-23f6037d1ad0"/*SearchAndReplace*/,
       "Position": {
-        "X": 274.03662,
-        "Y": 169.15643
+        "X": 605.9165,
+        "Y": 229.44186
       }
     },
     {
@@ -296,6 +454,13 @@
       "Position": {
         "X": 1911.3387,
         "Y": 578.1874
+      }
+    },
+    {
+      "ChildId": "f8db1d5e-bf8f-4d55-89ea-ded2def3e1d7"/*GenerateMips*/,
+      "Position": {
+        "X": 2505.2117,
+        "Y": 841.4501
       }
     }
   ],

--- a/Operators/examples/lib/image/use/CustomPixelShaderExample.cs
+++ b/Operators/examples/lib/image/use/CustomPixelShaderExample.cs
@@ -1,0 +1,16 @@
+using T3.Core.Operator;
+using T3.Core.Operator.Attributes;
+using T3.Core.Operator.Slots;
+using System.Runtime.InteropServices;
+
+namespace Examples.Lib.image.use{
+    [Guid("af263c08-4f22-45a4-ad8c-caeb813c237b")]
+    internal sealed class CustomPixelShaderExample : Instance<CustomPixelShaderExample>
+    {
+
+        [Output(Guid = "c18cb083-0743-45ae-bb29-b2fa23803418")]
+        public readonly Slot<T3.Core.DataTypes.Texture2D> ColorBuffer = new Slot<T3.Core.DataTypes.Texture2D>();
+
+    }
+}
+

--- a/Operators/examples/lib/image/use/CustomPixelShaderExample.t3
+++ b/Operators/examples/lib/image/use/CustomPixelShaderExample.t3
@@ -1,0 +1,2272 @@
+{
+  "Id": "af263c08-4f22-45a4-ad8c-caeb813c237b"/*CustomPixelShaderExample*/,
+  "Inputs": [],
+  "Children": [
+    {
+      "Id": "03ae835b-8257-4c2d-844e-c1015343dc4e"/*scale*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "scale",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 4.73
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "05b5391b-1ef0-4901-a4d4-665a52ec659b"/*Color*/,
+      "SymbolId": "70176d3c-825c-40b3-8121-a465735518fe",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "099ca1ee-8496-4ac4-a899-da0cf7acada5"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 1.0
+        },
+        {
+          "Id": "60bdd684-8005-4576-b09b-1b5d6124da1d"/*C*/,
+          "Type": "System.Single",
+          "Value": 1.4
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.85,
+            "Y": 0.5
+          }
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 0.7
+        },
+        {
+          "Id": "fb8d51fe-b4c2-452a-9e53-b649aed92bd7"/*IgnoreTemplate*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "0c8091e6-556c-4441-8efa-d03f76351851"/*AnimValue*/,
+      "SymbolId": "ea7b8491-2f8e-4add-b0b1-fd068ccfed0d",
+      "InputValues": [
+        {
+          "Id": "48005727-0158-4795-ad70-8410c27fd01d"/*Rate*/,
+          "Type": "System.Single",
+          "Value": 0.3
+        },
+        {
+          "Id": "79917ef7-64ca-4825-9c6a-c9b2a7f6ff86"/*Amplitude*/,
+          "Type": "System.Single",
+          "Value": 10.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "0e697437-0396-49f9-bfc8-03679a8d9e7a"/*ValGain*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "ValGain",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.3
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "0ec684a6-e48b-4185-9f4a-b6b5121a921d"/*BlendAB*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "BlendAB",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.37
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "0fba74b7-c888-4996-998f-dedb8c6d05fe"/*mipbias*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "mipbias",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1005741b-ddec-4da5-9a60-3b96a53af1f3"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "1008221d-295a-4866-85fe-9ce57a4dc2aa"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "1504210f-88b2-4928-b600-b157cfd1476f"/*StretchAngle*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "StretchAngle",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": -0.05
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1611ddeb-6158-4d48-9110-3d7db9b7186a"/*RadialPoints*/,
+      "SymbolId": "3352d3a1-ab04-4d0a-bb43-da69095b73fd",
+      "InputValues": [
+        {
+          "Id": "5f5394b4-b23e-41bf-8089-b5c063623e66"/*Color*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 1.0,
+            "Z": 1.0,
+            "W": 1.0
+          }
+        },
+        {
+          "Id": "b654ffe2-d46e-4a62-89b3-a9692d5c6481"/*Count*/,
+          "Type": "System.Int32",
+          "Value": 2048
+        },
+        {
+          "Id": "ca84209e-d821-40c6-b23c-38fc4bbd47b0"/*Center*/,
+          "Type": "System.Numerics.Vector3",
+          "Value": {
+            "X": 0.0,
+            "Y": 0.76,
+            "Z": 0.0
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "16ff6272-3eff-4f08-a1fb-6f1aa1b4d7d1"/*expscale*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "expscale",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.8
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "17705b04-a8f5-469e-91c8-d405511e05d6"/*displace*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "displace",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.27
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "1cb7100c-0052-460a-8df9-81d7486f3c7d"/*SamplerState*/,
+      "SymbolId": "9515d59d-0bd5-406b-96da-6a5f60215700",
+      "InputValues": [
+        {
+          "Id": "93d8bf26-5067-4ccc-b4cb-e03970686462"/*AddressW*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Clamp"
+        },
+        {
+          "Id": "e7c95fd5-14d1-434f-a140-f22ef69076ab"/*AddressU*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Clamp"
+        },
+        {
+          "Id": "fdeb503f-09c6-48d1-8853-7426f68cdec3"/*AddressV*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Wrap"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "227072ad-e81b-4503-9179-daac5f0bdb42"/*RenderTarget*/,
+      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
+      "InputValues": [
+        {
+          "Id": "8bb4a4e5-0c88-4d99-a5b2-2c9e22bd301f"/*ClearColor*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 0.0,
+            "Y": 0.0,
+            "Z": 0.5,
+            "W": 1.0
+          }
+        },
+        {
+          "Id": "e882e0f0-03f9-46e6-ac7a-709e6fa66613"/*Multisampling*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "ec46bef4-8dce-4eb4-bfe8-e35a5ac416ec"/*TextureFormat*/,
+          "Type": "SharpDX.DXGI.Format",
+          "Value": "R8G8B8A8_UNorm"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "2542e77e-540d-44af-b334-0b4e620f17e6"/*G*/,
+      "SymbolId": "fd31d208-12fe-46bf-bfa3-101211f8f497",
+      "Name": "G",
+      "InputValues": [
+        {
+          "Id": "d89c518c-a862-4f46-865b-0380350b7417"/*Size*/,
+          "Type": "System.Single",
+          "Value": 192.0
+        },
+        {
+          "Id": "f1f1be0e-d5bc-4940-bbc1-88bfa958f0e1"/*InputText*/,
+          "Type": "System.String",
+          "Value": "Green"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "270e4d1a-921b-46ce-8d1e-578e07b09eb0"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.55
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.0,
+            "Y": 1.14
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "c=Image.Sample(Sampler,uv,0);\nc.a=B;"
+        },
+        {
+          "Id": "a965b7d3-c78f-4da7-ae70-c461cc9b173c"/*Clear*/,
+          "Type": "System.Boolean",
+          "Value": false
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 0.1
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": ""
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "27ef94ac-d4b0-4a21-861b-6dc5716c9eac"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "2fdf8ebd-40fb-4c75-9ae1-4964ab4e5700"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": -0.05,
+            "Y": 0.16
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 dir=Center;\ndir=length(dir)>0?dir:float2(0.6,1);\nuv=(uv-.5)*exp2(B)/dot(uv-.24,dir)+.5;\n\n\nc= Image.SampleBias(CustomSampler, uv,A);\n\n"
+        },
+        {
+          "Id": "92fdfa08-e7da-4a71-9145-277b74c93729"/*GenerateMips*/,
+          "Type": "System.Boolean",
+          "Value": true
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 2.58
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "30a87eb9-b89d-407a-b7b6-91821381005d"/*R*/,
+      "SymbolId": "fd31d208-12fe-46bf-bfa3-101211f8f497",
+      "Name": "R",
+      "InputValues": [
+        {
+          "Id": "de0fed7d-d2af-4424-baf3-81606e26559f"/*Position*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.0,
+            "Y": 0.4
+          }
+        },
+        {
+          "Id": "f1f1be0e-d5bc-4940-bbc1-88bfa958f0e1"/*InputText*/,
+          "Type": "System.String",
+          "Value": "Red"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "37eecdbd-be04-4a06-87ed-ecff38e40043"/*offset*/,
+      "SymbolId": "926ab3fd-fbaf-4c4b-91bc-af277000dcb8",
+      "Name": "offset",
+      "InputValues": [
+        {
+          "Id": "2d9c040d-5244-40ac-8090-d8d57323487b"/*Y*/,
+          "Type": "System.Single",
+          "Value": -0.44
+        },
+        {
+          "Id": "6b9d0106-78f9-4507-a0f6-234c5dfb0f85"/*X*/,
+          "Type": "System.Single",
+          "Value": -0.93
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "3b45ce92-9527-4c15-bf46-1eb56b493d5b"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "3bd6be50-324f-40f7-b709-b267d0ab503b"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.16
+        },
+        {
+          "Id": "60bdd684-8005-4576-b09b-1b5d6124da1d"/*C*/,
+          "Type": "System.Single",
+          "Value": 0.91
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float4 smp= Image.Sample(Sampler, uv);\n\nfloat3 hsv=rgb2hsv(smp.rgb);\nhsv.x=(hsv.x-0.5)*B+0.5+A;\nhsv.y=ApplyGainAndBias(hsv.y,float2(C,D));\nc=smp;\nc.rgb=hsv2rgb(hsv);\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 1.0
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/bias-functions.hlsl\"\nfloat3 hsv2rgb(float3 hsv){return lerp(1,saturate(abs(frac((hsv.x-float3(0,2,4)/6))-.5)*6-1),hsv.y)*hsv.z;}\nfloat3 rgb2hsv(float3 c){\n     float v=max(c.x,max(c.y,c.z));float m=min(c.x,min(c.y,c.z));float r=v-m;\n     float h=(r!=0)?frac(((v==c.x)?((c.y-c.z)/r):(v==c.y)?(2+(c.z-c.x)/r):(4+(c.x-c.y)/r))/6):0;\n     float s=(v!=0)?(1-m/v):0;\n     return float3(h,s,v);\n}"
+        },
+        {
+          "Id": "db522fd4-5cfc-49f6-9983-02ec0dd6090a"/*D*/,
+          "Type": "System.Single",
+          "Value": 0.59
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "3f1e969f-1829-49b1-8614-9bb96527a1a0"/*offset*/,
+      "SymbolId": "926ab3fd-fbaf-4c4b-91bc-af277000dcb8",
+      "Name": "offset",
+      "InputValues": [
+        {
+          "Id": "2d9c040d-5244-40ac-8090-d8d57323487b"/*Y*/,
+          "Type": "System.Single",
+          "Value": -0.44
+        },
+        {
+          "Id": "6b9d0106-78f9-4507-a0f6-234c5dfb0f85"/*X*/,
+          "Type": "System.Single",
+          "Value": 0.04
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "418b1206-09d2-4a5d-82dd-7acd9a97ea2f"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 uvc=uv;\nuint2 tex2size;\nImage2.GetDimensions(tex2size.x, tex2size.y);\n\nc= Image2.Load(int3(floor(uv*tex2size),0));\n\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "43212e58-a045-4aa7-ba5a-d3de218030dc"/*B*/,
+      "SymbolId": "fd31d208-12fe-46bf-bfa3-101211f8f497",
+      "Name": "B",
+      "InputValues": [
+        {
+          "Id": "de0fed7d-d2af-4424-baf3-81606e26559f"/*Position*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.0,
+            "Y": -0.4
+          }
+        },
+        {
+          "Id": "f1f1be0e-d5bc-4940-bbc1-88bfa958f0e1"/*InputText*/,
+          "Type": "System.String",
+          "Value": "Blue"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "470cf286-6c57-4b58-8753-46da132d6ad6"/*String*/,
+      "SymbolId": "5880cbc3-a541-4484-a06a-0e6f77cdbe8e",
+      "InputValues": [
+        {
+          "Id": "ceeae47b-d792-471d-a825-49e22749b7b9"/*InputString*/,
+          "Type": "System.String",
+          "Value": "cbuffer ParamConstants : register(b0)\n{\n    float2 Center;\n    float A;\n    float B;\n    float C;\n    float D;\n\n}\n\ncbuffer Resolution : register(b1)\n{\n    float TargetWidth;\n    float TargetHeight;\n}\n\ncbuffer AdditionalParams : register(b2)\n{\n    float Scale;\n    float BlendAB;\n    float BlendC;\n    float Temp;\n    float2 Position;\n}\n\nstruct vsOutput\n{\n    float4 position : SV_POSITION;\n    float2 texCoord : TEXCOORD;\n};\n//first two texture inputs\nTexture2D<float4> Image : register(t0);\nTexture2D<float4> Image2 : register(t1);\n//texture input as SRV\nTexture2D<float4> Image3 : register(t2);\n\n\nsampler Sampler : register(s0);\n//input samplers\nsampler CustomSampler : register(s1);\nsampler Sampler2 : register(s2);\n\nfloat4 psMain(vsOutput input) : SV_TARGET\n{\n    float width, height;\n    Image.GetDimensions(width, height);\n    float4 c=float4(1,1,0,1);\n   \n    float2 uv = input.texCoord;\n    int2 TargetSize=int2(TargetWidth,TargetHeight);\n    int2 PixelCoord=int2(round(uv*TargetSize-.25));\n    \n\n    c= Image.Sample(Sampler, uv);\n\n    float2 uv2=(uv-Position)*exp2(Scale)+Position;\n\n    float4 c2=Image2.Sample(Sampler2, uv2);\n    c= lerp(c,c2,c2.a*BlendAB);\n\n    float4 c3=Image3.Sample(CustomSampler, uv2);\n    c3.xyz=lerp(c3.xyz,dot(c3.xyz,1./3),Temp);\n    c=lerp(c,c3,c3.a*BlendC);\n\n\n    return c;\n}"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "4890bfd3-47e4-4d7b-9c02-177530e1b0db"/*AnimValue*/,
+      "SymbolId": "ea7b8491-2f8e-4add-b0b1-fd068ccfed0d",
+      "InputValues": [
+        {
+          "Id": "79917ef7-64ca-4825-9c6a-c9b2a7f6ff86"/*Amplitude*/,
+          "Type": "System.Single",
+          "Value": 360.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "520660a9-53bb-490a-9add-4dd43852e509"/*AnimValue*/,
+      "SymbolId": "ea7b8491-2f8e-4add-b0b1-fd068ccfed0d",
+      "InputValues": [
+        {
+          "Id": "48005727-0158-4795-ad70-8410c27fd01d"/*Rate*/,
+          "Type": "System.Single",
+          "Value": 0.618
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "5361507f-bbfd-4a3d-a07e-53f706cd50cd"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.32
+        },
+        {
+          "Id": "60bdd684-8005-4576-b09b-1b5d6124da1d"/*C*/,
+          "Type": "System.Single",
+          "Value": 0.52
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.0,
+            "Y": 0.0
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 asp=float2(TargetSize)/TargetSize.y;\nfloat3 p=float3((uv-0.5)*asp,0);\np=p*B+float3(Center,A);\n//float3 smp=curlNoise2(p);\nfloat3 smp=snoiseVec3(p);\nuv+=smp.xy*C/asp;\nuv=clamp(uv,0.5/TargetSize,1.0-0.5/TargetSize);\nc=Image.SampleLevel(Sampler, uv,0);\nc.a=1;\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 2.76
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/noise-functions.hlsl\"\n\nfloat3 curlNoise2(float3 p)\n{\n  const float e = .01;\n  float3 dx = float3(e, 0.0, 0.0);\n  float3 dy = float3(0.0, e, 0.0);\n  float3 dz = float3(0.0, 0.0, e);\n\n  float3 p_x0 = snoiseVec3(p - dx);\n  float3 p_x1 = snoiseVec3(p + dx);\n  float3 p_y0 = snoiseVec3(p - dy);\n  float3 p_y1 = snoiseVec3(p + dy);\n  float3 p_z0 = snoiseVec3(p - dz);\n  float3 p_z1 = snoiseVec3(p + dz);\n\n  float x = p_y1.z - p_y0.z - p_z1.y + p_z0.y;\n  float y = p_z1.x - p_z0.x - p_x1.z + p_x0.z;\n  float z = p_x1.y - p_x0.y - p_y1.x + p_y0.x;\n\n  const float divisor = 1.0 / (2.0 * e);\n  return normalize(float3(x, y, z) * divisor);\n}"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "563fb13f-67a8-4576-a6cb-15e7abec997a"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "5858e6d9-a533-48e6-a0b0-cf60debc3b4c"/*Position*/,
+      "SymbolId": "926ab3fd-fbaf-4c4b-91bc-af277000dcb8",
+      "Name": "Position",
+      "InputValues": [
+        {
+          "Id": "2d9c040d-5244-40ac-8090-d8d57323487b"/*Y*/,
+          "Type": "System.Single",
+          "Value": 0.89
+        },
+        {
+          "Id": "6b9d0106-78f9-4507-a0f6-234c5dfb0f85"/*X*/,
+          "Type": "System.Single",
+          "Value": 0.83
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "5cb28ad6-b4bc-4768-ba83-e09cb28e16e6"/*StretchScale*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "StretchScale",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 5.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "6296b80f-0d34-4536-8d85-552cc1855e35"/*Vector4Components*/,
+      "SymbolId": "b15e4950-5c72-4655-84bc-c00647319030",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "62c3bc21-9bdd-40ab-83bf-a768c3b3fc3a"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "64946e74-6f35-4bda-821c-f9283304d9b4"/*Temp*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "Temp",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "6675e7ce-737a-4126-9658-3b12b78951e6"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.24
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": -0.1,
+            "Y": 2.42
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 asp=float2(TargetSize)/TargetSize.y;\nfloat3 p=float3((uv-0.5)*asp,0);\np=p*B+float3(Center,A);\nc.xyz=snoiseVec3(p);\nc.a=1;\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 4.0
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/noise-functions.hlsl\"\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "6977a3c8-63f9-4eaa-9ac3-85f6ea70a4dd"/*Displace*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "Displace",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": -0.51
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "6ed76894-3875-4220-9acd-d1b664f76746"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 5.42
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "uv=(uv-0.5-Center)*exp2(B)+Center+0.5;\nc= Image.SampleBias(CustomSampler, uv,A);\n//c= Image.SampleLevel(CustomSampler, (uv-0.5)*exp2(B)+0.5,A);"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 4.1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "6f14f3e8-ecd8-4e8a-99a1-b5406cbe0fd6"/*AddNoise*/,
+      "SymbolId": "dd586355-64b3-4e96-af6d-b4927595dee7",
+      "InputValues": [
+        {
+          "Id": "5894156a-cc31-4236-908c-de0e5385fd84"/*Strength*/,
+          "Type": "System.Single",
+          "Value": 4.0
+        },
+        {
+          "Id": "929db7b2-f19c-4a28-b4c2-187365b99760"/*Frequency*/,
+          "Type": "System.Single",
+          "Value": 3.0
+        },
+        {
+          "Id": "aaba1602-e7a1-4b48-81d4-9d7b2b3aa8b1"/*Phase*/,
+          "Type": "System.Single",
+          "Value": 0.7
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "7086900d-a6b2-4e4f-a4ad-10a7a950d684"/*GenerateMips*/,
+      "SymbolId": "ed0f5188-8888-453e-8db4-20d87d18e9f4",
+      "Name": "GenerateMips",
+      "InputValues": [
+        {
+          "Id": "e7c1f0af-da6d-4e33-ac86-7dc96bfe7eb3"/*BoolValue*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "729d44cd-11dc-40b6-bc6e-066484aab39b"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": -0.04
+        },
+        {
+          "Id": "60bdd684-8005-4576-b09b-1b5d6124da1d"/*C*/,
+          "Type": "System.Single",
+          "Value": 0.3
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float4 smp= Image.Sample(Sampler, uv);\n\nfloat3 hsv=rgb2hsv(smp.rgb);\nfloat2 v=r2d(float2(0,-hsv.y),hsv.x+A);\nv.x*=B;\n\nhsv.x=atan2(v.x,v.y)/acos(-1)/2+.5-A;\nhsv.y=length(v);\nhsv.z=ApplyGainAndBias(hsv.z,float2(C,D));\nc=smp;\nc.rgb=hsv2rgb(hsv);\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 2.0
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/bias-functions.hlsl\"\nfloat2 r2d(float2 x,float a){a*=acos(-1)*2;return float2(cos(a)*x.x+sin(a)*x.y,cos(a)*x.y-sin(a)*x.x);}\nfloat3 hsv2rgb(float3 hsv){return lerp(1,saturate(abs(frac((hsv.x-float3(0,2,4)/6))-.5)*6-1),hsv.y)*hsv.z;}\nfloat3 rgb2hsv(float3 c){\n     float v=max(c.x,max(c.y,c.z));float m=min(c.x,min(c.y,c.z));float r=v-m;\n     float h=(r!=0)?frac(((v==c.x)?((c.y-c.z)/r):(v==c.y)?(2+(c.z-c.x)/r):(4+(c.x-c.y)/r))/6):0;\n     float s=(v!=0)?(1-m/v):0;\n     return float3(h,s,v);\n}"
+        },
+        {
+          "Id": "db522fd4-5cfc-49f6-9983-02ec0dd6090a"/*D*/,
+          "Type": "System.Single",
+          "Value": 0.3
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "735bf1c0-df83-42b6-8aae-a19aa3ed0cf3"/*ValBias*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "ValBias",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.3
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "75ba1de0-50b4-4368-be45-b1a1beaacb89"/*phase*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "phase",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 8.11
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "78765ddb-730d-4538-947f-0895a318b297"/*SrvFromTexture2d*/,
+      "SymbolId": "c2078514-cf1d-439c-a732-0d7b31b5084a",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "799f9083-a102-49e1-82b8-ccc757f3d379"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "uv+=Center;\nc=  float4(uv,0,1);\nc.x= Image.Sample(Sampler, uv).x;\nc.y= Image2.Sample(Sampler, uv).y;\nc.z= Image3.Sample(Sampler, uv).z;\nc.w= Image4.Sample(Sampler, uv).x;\nint gs=max(1,Index);\nint ch=( uint((PixelCoord.x)/gs)%2 )\n      ^( uint((PixelCoord.y)/gs)%2 );\nc.w=max(c.w,0.25*float(ch)*float(Index>0));\nc*=Color;\n//c.a=1;"
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "Texture2D<float4> Image3 : register(t2);\nTexture2D<float4> Image4 : register(t3);\n\ncbuffer AdditionalIntParams : register(b2)\n{\n    int Index;\n}\ncbuffer AdditionalFloatParams : register(b3)\n{\n    float4 Color;\n}"
+        },
+        {
+          "Id": "fb8d51fe-b4c2-452a-9e53-b649aed92bd7"/*IgnoreTemplate*/,
+          "Type": "System.Boolean",
+          "Value": false
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "79b61f85-27f8-4087-bba4-f2f5bbcd2166"/*resize 64x64*/,
+      "SymbolId": "32e18957-3812-4f64-8663-18454518d005",
+      "Name": "resize 64x64",
+      "InputValues": [
+        {
+          "Id": "5c76dc8d-3a28-4b93-b3a0-e008c1ff14e9"/*Resolution*/,
+          "Type": "T3.Core.DataTypes.Vector.Int2",
+          "Value": {
+            "X": 87,
+            "Y": 64
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "7b469aed-af76-4f64-a86f-2fb34f5c1acb"/*TransformImage*/,
+      "SymbolId": "32e18957-3812-4f64-8663-18454518d005",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "7c3c1327-2e55-4356-862d-b214bd0e91dd"/*HueOffset*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "HueOffset",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "7cd0a1f7-ce45-4333-ab91-8ed13a42a15a"/*SatGain*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "SatGain",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.68
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0"/*FloatsToBuffer*/,
+      "SymbolId": "724da755-2d0c-42ab-8335-8c88ec5fb078",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "820b11a9-cc8b-42f2-a77b-1c850206a506"/*GetBufferComponents*/,
+      "SymbolId": "80dff680-5abf-484a-b9e0-81d72f3b7aa4",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "84a2e769-bc6c-4695-b944-ce518353da56"/*IntsToBuffer*/,
+      "SymbolId": "2eb20a76-f8f7-49e9-93a5-1e5981122b50",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "84bb4500-26e4-4172-b9b3-d53d63b0cb7d"/*Vector2Components*/,
+      "SymbolId": "0946c48b-85d8-4072-8f21-11d17cc6f6cf",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "853081ae-5bd4-4145-83f0-c3d3c1e2a9ee"/*expscale*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "expscale",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": -1.1
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "862952a2-0074-462d-85de-ba65fb756145"/*stretch*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "Name": "stretch",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 uvc=uv;\nuint2 tex2size;\nImage2.GetDimensions(tex2size.x, tex2size.y);\n\nc= Image2.Load(int3(floor(uv*tex2size),0));\n\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "87ad5a77-11f3-429b-bc1b-689849ec9cec"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "8985c6dd-f497-496d-8ccd-2549e25970be"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        },
+        {
+          "Id": "60bdd684-8005-4576-b09b-1b5d6124da1d"/*C*/,
+          "Type": "System.Single",
+          "Value": -0.2
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 asp=float2(TargetSize)/TargetSize.y;\nint iter=8;\nfor(int i=0;i<iter;i++){\n  float f=float(i)/iter;\n  float3 smp=Image2.SampleLevel(Sampler, uv,0);\n  uv+=smp.xy*C/iter/asp;\n}\n\nuv=clamp(uv,0.5/TargetSize,1.0-0.5/TargetSize);\nc=Image.SampleLevel(Sampler, uv,0);\nc.a=1;\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 3.56
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/noise-functions.hlsl\"\n\nfloat3 curlNoise2(float3 p)\n{\n  const float e = .01;\n  float3 dx = float3(e, 0.0, 0.0);\n  float3 dy = float3(0.0, e, 0.0);\n  float3 dz = float3(0.0, 0.0, e);\n\n  float3 p_x0 = snoiseVec3(p - dx);\n  float3 p_x1 = snoiseVec3(p + dx);\n  float3 p_y0 = snoiseVec3(p - dy);\n  float3 p_y1 = snoiseVec3(p + dy);\n  float3 p_z0 = snoiseVec3(p - dz);\n  float3 p_z1 = snoiseVec3(p + dz);\n\n  float x = p_y1.z - p_y0.z - p_z1.y + p_z0.y;\n  float y = p_z1.x - p_z0.x - p_x1.z + p_x0.z;\n  float z = p_x1.y - p_x0.y - p_y1.x + p_y0.x;\n\n  const float divisor = 1.0 / (2.0 * e);\n  return normalize(float3(x, y, z) * divisor);\n}"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "8cee3c58-1dc5-490f-a9c9-6d1002f02d32"/*Scale*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "Scale",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 1.34
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "8f0f7586-73ea-4db5-8792-2c99bf51b209"/*RenderTarget*/,
+      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
+      "InputValues": [
+        {
+          "Id": "e882e0f0-03f9-46e6-ac7a-709e6fa66613"/*Multisampling*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "ec46bef4-8dce-4eb4-bfe8-e35a5ac416ec"/*TextureFormat*/,
+          "Type": "SharpDX.DXGI.Format",
+          "Value": "R8G8B8A8_UNorm"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "94869a8f-d975-4e11-b58a-75cb24722523"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [
+        {
+          "Id": "76cc3811-4ae0-48b2-a119-890db5a4eeb2"/*Path*/,
+          "Type": "System.String",
+          "Value": "/t3/images/frog2.jpg"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "9665e9f3-8f6a-494b-afcc-a19950163db7"/*A*/,
+      "SymbolId": "fd31d208-12fe-46bf-bfa3-101211f8f497",
+      "Name": "A",
+      "InputValues": [
+        {
+          "Id": "d89c518c-a862-4f46-865b-0380350b7417"/*Size*/,
+          "Type": "System.Single",
+          "Value": 1300.0
+        },
+        {
+          "Id": "de0fed7d-d2af-4424-baf3-81606e26559f"/*Position*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.0,
+            "Y": -0.1
+          }
+        },
+        {
+          "Id": "f1f1be0e-d5bc-4940-bbc1-88bfa958f0e1"/*InputText*/,
+          "Type": "System.String",
+          "Value": "A"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "97c5f3d0-29e8-4f33-9892-19ce1e34c978"/*AnimValue*/,
+      "SymbolId": "ea7b8491-2f8e-4add-b0b1-fd068ccfed0d",
+      "InputValues": [
+        {
+          "Id": "48005727-0158-4795-ad70-8410c27fd01d"/*Rate*/,
+          "Type": "System.Single",
+          "Value": 0.1
+        },
+        {
+          "Id": "79917ef7-64ca-4825-9c6a-c9b2a7f6ff86"/*Amplitude*/,
+          "Type": "System.Single",
+          "Value": 10.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "97ed6799-a5eb-49a7-abff-760989a12120"/*Sampler2*/,
+      "SymbolId": "9515d59d-0bd5-406b-96da-6a5f60215700",
+      "Name": "Sampler2",
+      "InputValues": [
+        {
+          "Id": "93d8bf26-5067-4ccc-b4cb-e03970686462"/*AddressW*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Clamp"
+        },
+        {
+          "Id": "e7c95fd5-14d1-434f-a140-f22ef69076ab"/*AddressU*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Mirror"
+        },
+        {
+          "Id": "fdeb503f-09c6-48d1-8853-7426f68cdec3"/*AddressV*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Mirror"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "9c50a330-12c5-4275-915c-c5884b3544e3"/*WaveForm*/,
+      "SymbolId": "92e28e50-bd40-4f93-ba92-8f69cded6ec1",
+      "InputValues": [
+        {
+          "Id": "c3eb1998-3bbf-436c-bde8-9fbbf4f56e54"/*ShowVectorscope*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "a2939f70-cd4a-42b5-9337-e550f6cee3e8"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "a351e265-3787-42e6-981c-ae0a55a8c1c9"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "a574f8d0-16ec-412f-b4bf-1d210398bfab"/*SrvFromTexture2d*/,
+      "SymbolId": "c2078514-cf1d-439c-a732-0d7b31b5084a",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "a9792082-4c97-493e-a5b2-40bde33395fb"/*Blob*/,
+      "SymbolId": "27b0e1af-cb2e-4603-83f9-5c9b042d87e6",
+      "InputValues": [
+        {
+          "Id": "7daacb43-54de-47d2-afcd-694f6afce59d"/*Position*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": -0.655,
+            "Y": -0.29
+          }
+        },
+        {
+          "Id": "d2b0dd99-c289-4c1b-9335-c29a6b4a6ba3"/*Color*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 0.56452894,
+            "Z": 0.65884197,
+            "W": 0.4
+          }
+        },
+        {
+          "Id": "fd05c355-7afa-4af6-9529-d4071d145d3b"/*Background*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 0.44,
+            "Y": 0.86,
+            "Z": 0.84,
+            "W": 0.0
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "abcfabd0-ed2a-47c6-9f4b-c220e846e41c"/*phase*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "phase",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": -0.44
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b1e180a9-646d-4b4b-a4ab-8563474110a2"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 2.0
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "uv+=Center;\nc=  float4(uv,0,1);\nc*= Image.Sample(Sampler, uv);\nc*=A;"
+        },
+        {
+          "Id": "92fdfa08-e7da-4a71-9145-277b74c93729"/*GenerateMips*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b1f420b0-1671-4f42-8327-d07e6f8b75de"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "83e06d04-02bd-40cc-8666-d5dd62a9e63e"/*Resolution*/,
+          "Type": "T3.Core.DataTypes.Vector.Int2",
+          "Value": {
+            "X": 512,
+            "Y": 16
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "uint numStructs, stride;\nSourcePoints.GetDimensions(numStructs, stride);\nint idx=PixelCoord.x+(PixelCoord.y/4)*TargetSize.x;\nint ir=PixelCoord.y%4;\nif(idx<numStructs){\n    Point p=SourcePoints[idx];\n    if(ir==0)c=float4(p.Position.xyz,p.FX1);\n    if(ir==1)c=float4(p.Rotation.xyzw);\n    if(ir==2)c=float4(p.Color.xyzw);\n    if(ir==3)c=float4(p.Scale.xyz,p.FX2);\n}\nc.a=1;"
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/point.hlsl\"\nStructuredBuffer<Point> SourcePoints : t2;\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b6e53ef3-1935-4e5b-a309-4aaf2bd183a8"/*miplevel*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "miplevel",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b704984d-cb1c-4703-b1e0-df79e4fdf7d5"/*HueCycles*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "HueCycles",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 6.0
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b8ca8474-560f-4c7e-b485-0f3ee2c6f08f"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.33
+        },
+        {
+          "Id": "60bdd684-8005-4576-b09b-1b5d6124da1d"/*C*/,
+          "Type": "System.Single",
+          "Value": 0.11
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "c.rgb=ReadGrayscale(uv);"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 0.59
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "float ReadGrayscale(float2 uv){\n    return dot(Image.Sample(Sampler,uv,0),float4(A,B,C,D));\n}"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "b9b8de62-ae21-4672-b782-a91189992843"/*LoadImage*/,
+      "SymbolId": "0b3436db-e283-436e-ba85-2f3a1de76a9d",
+      "InputValues": [
+        {
+          "Id": "76cc3811-4ae0-48b2-a119-890db5a4eeb2"/*Path*/,
+          "Type": "System.String",
+          "Value": "/t3/images/chipmunk.jpg"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "bd5d133a-e2a1-458e-aa8d-75af79ad83e1"/*scale*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "scale",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 1.22
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "bee3c8a7-899f-49a4-99ae-0357d7ab7554"/*FloatsToBuffer*/,
+      "SymbolId": "724da755-2d0c-42ab-8335-8c88ec5fb078",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "c0debbb5-e51c-478c-a510-cbcffdef5555"/*WaveForm*/,
+      "SymbolId": "92e28e50-bd40-4f93-ba92-8f69cded6ec1",
+      "InputValues": [
+        {
+          "Id": "c3eb1998-3bbf-436c-bde8-9fbbf4f56e54"/*ShowVectorscope*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c11dfd71-84b8-4681-8659-7926b3d236e0"/*RandomizePoints*/,
+      "SymbolId": "ec0675d7-6b72-4b15-b141-80bdd2367cd8",
+      "InputValues": [
+        {
+          "Id": "270bcf23-35ee-4c4f-aae5-192435b1aee3"/*Position*/,
+          "Type": "System.Numerics.Vector3",
+          "Value": {
+            "X": 0.1,
+            "Y": 0.1,
+            "Z": 0.1
+          }
+        },
+        {
+          "Id": "4dffb439-da81-477c-8100-34a9ba59b0ee"/*RandomPhase*/,
+          "Type": "System.Single",
+          "Value": 10.4
+        },
+        {
+          "Id": "dd46595e-01e5-4616-9682-3a4eb7f63016"/*ColorHSB*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 1.0,
+            "Y": 1.0,
+            "Z": 0.5,
+            "W": 0.0
+          }
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c12886a4-3384-44a2-8e92-40d3314c9d1a"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "c= Image.Sample(Sampler, uv);"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c16fd9b2-69a2-4a63-a173-af762d5f91ec"/*phase*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "phase",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.21
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c2630922-354e-4655-8d29-285604bc24ea"/*RenderTarget*/,
+      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
+      "InputValues": [
+        {
+          "Id": "8bb4a4e5-0c88-4d99-a5b2-2c9e22bd301f"/*ClearColor*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 0.5,
+            "Y": 0.0,
+            "Z": 0.0,
+            "W": 1.0
+          }
+        },
+        {
+          "Id": "e882e0f0-03f9-46e6-ac7a-709e6fa66613"/*Multisampling*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "ec46bef4-8dce-4eb4-bfe8-e35a5ac416ec"/*TextureFormat*/,
+          "Type": "SharpDX.DXGI.Format",
+          "Value": "R8G8B8A8_UNorm"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "c323214b-79c5-4ccb-96c8-880d45f0ca32"/*fit height*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "Name": "fit height",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.0
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 uvc=uv;\nuint2 tex2size;\nImage2.GetDimensions(tex2size.x, tex2size.y);\n\nfloat2 asp=float2(TargetSize)/TargetSize.y;\nfloat2 asp2=float2(tex2size)/tex2size.y;\nuvc=(uv-0.5)*asp/asp2+0.5;\nc= Image2.Load(int3(floor(uvc*tex2size),0));\n//uvc=(floor(uvc*tex2size)+0.5)/tex2size;\n//c= Image2.SampleLevel(Sampler, uvc,0);\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "cdded62e-6380-420b-a3fc-9a21960c8d0f"/*RenderTarget*/,
+      "SymbolId": "f9fe78c5-43a6-48ae-8e8c-6cdbbc330dd1",
+      "InputValues": [
+        {
+          "Id": "8bb4a4e5-0c88-4d99-a5b2-2c9e22bd301f"/*ClearColor*/,
+          "Type": "System.Numerics.Vector4",
+          "Value": {
+            "X": 0.0,
+            "Y": 0.5,
+            "Z": 0.0,
+            "W": 1.0
+          }
+        },
+        {
+          "Id": "e882e0f0-03f9-46e6-ac7a-709e6fa66613"/*Multisampling*/,
+          "Type": "System.Int32",
+          "Value": 1
+        },
+        {
+          "Id": "ec46bef4-8dce-4eb4-bfe8-e35a5ac416ec"/*TextureFormat*/,
+          "Type": "SharpDX.DXGI.Format",
+          "Value": "R8G8B8A8_UNorm"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "d0247b50-18f7-4fa1-a12f-5c27393f3233"/*AlphaGridSize*/,
+      "SymbolId": "cc07b314-4582-4c2c-84b8-bb32f59fc09b",
+      "Name": "AlphaGridSize",
+      "InputValues": [
+        {
+          "Id": "4515c98e-05bc-4186-8773-4d2b31a8c323"/*Int*/,
+          "Type": "System.Int32",
+          "Value": 32
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "d1606023-2bdc-4ab2-a8b6-da2f08cca3e4"/*CustomSampler*/,
+      "SymbolId": "9515d59d-0bd5-406b-96da-6a5f60215700",
+      "Name": "CustomSampler",
+      "InputValues": [
+        {
+          "Id": "93d8bf26-5067-4ccc-b4cb-e03970686462"/*AddressW*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Clamp"
+        },
+        {
+          "Id": "e7c95fd5-14d1-434f-a140-f22ef69076ab"/*AddressU*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Border"
+        },
+        {
+          "Id": "fdeb503f-09c6-48d1-8853-7426f68cdec3"/*AddressV*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Border"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "d1aa2c88-7dac-4ee1-b2f8-bbf389436e61"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 1.44
+        },
+        {
+          "Id": "60bdd684-8005-4576-b09b-1b5d6124da1d"/*C*/,
+          "Type": "System.Single",
+          "Value": 0.73
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": -0.1,
+            "Y": 2.42
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 asp=float2(TargetSize)/TargetSize.y;\nfloat3 p=float3((uv-0.5)*asp,0);\np=p*B+float3(Center,A);\nfloat4 smp=Image.SampleLevel(Sampler, uv,0);\np+=(smp.xyz-0.5)*C;\nc.xyz=snoiseVec3(p)*0.5+0.5;\n\nc.a=1;\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 8.0
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/noise-functions.hlsl\"\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "d93e7c9d-97f5-42a2-a58d-63adaca0852d"/*WaveForm*/,
+      "SymbolId": "92e28e50-bd40-4f93-ba92-8f69cded6ec1",
+      "InputValues": [
+        {
+          "Id": "c3eb1998-3bbf-436c-bde8-9fbbf4f56e54"/*ShowVectorscope*/,
+          "Type": "System.Boolean",
+          "Value": true
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "db47f590-cf4b-447b-b0db-5f9efc8dbe36"/*BlendC*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "BlendC",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 1.19
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "dfe6b047-b50c-45fa-a471-51b140a7bf40"/*Displace*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "Displace",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.27
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "e03a5d28-d6ee-4a34-886f-abf8f3ceac48"/*SamplerState*/,
+      "SymbolId": "9515d59d-0bd5-406b-96da-6a5f60215700",
+      "InputValues": [
+        {
+          "Id": "93d8bf26-5067-4ccc-b4cb-e03970686462"/*AddressW*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Mirror"
+        },
+        {
+          "Id": "e7c95fd5-14d1-434f-a140-f22ef69076ab"/*AddressU*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Mirror"
+        },
+        {
+          "Id": "fdeb503f-09c6-48d1-8853-7426f68cdec3"/*AddressV*/,
+          "Type": "SharpDX.Direct3D11.TextureAddressMode",
+          "Value": "Mirror"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "e0e2fd9c-2c40-431a-ba75-390d6258afe9"/*phase*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "phase",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 1.33
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "ef8d3108-5a53-43b1-97be-3325bc96e220"/*SrvFromTexture2d*/,
+      "SymbolId": "c2078514-cf1d-439c-a732-0d7b31b5084a",
+      "InputValues": [],
+      "Outputs": []
+    },
+    {
+      "Id": "efa10689-4626-4a6a-9902-032a1106428d"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "c= Image2.Sample(Sampler, uv);"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "f18cef05-680f-4516-8bb7-6c3880b6a8e0"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.55
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 0.0,
+            "Y": 1.14
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "c=Image.Sample(Sampler,uv,0);\n//if(abs(uv.y-A)>B)discard;\nc.a=smoothstep(0.0001+B,0,abs(uv.y-A));\n"
+        },
+        {
+          "Id": "a965b7d3-c78f-4da7-ae70-c461cc9b173c"/*Clear*/,
+          "Type": "System.Boolean",
+          "Value": false
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 0.03
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": ""
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "f22f1711-4fbf-4166-9087-2a1552eeaac9"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 1.44
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": -0.1,
+            "Y": 2.42
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 asp=float2(TargetSize)/TargetSize.y;\nfloat3 p=float3((uv-0.5)*asp,0);\np=p*B+float3(Center,A);\nc.xyz=snoiseVec3(p)*0.5+0.5;\nc.a=1;\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 8.0
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/noise-functions.hlsl\"\n"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "f8fa0591-10e4-4b29-813e-a6874ee77073"/*SatBias*/,
+      "SymbolId": "5d7d61ae-0a41-4ffa-a51d-93bab665e7fe",
+      "Name": "SatBias",
+      "InputValues": [
+        {
+          "Id": "7773837e-104a-4b3d-a41f-cadbd9249af2"/*Float*/,
+          "Type": "System.Single",
+          "Value": 0.27
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "fc753e82-4146-4a7b-96f9-3b377deeff3f"/*CustomPixelShader*/,
+      "SymbolId": "46daab0e-e957-413e-826c-0699569d0e07",
+      "InputValues": [
+        {
+          "Id": "3d84725a-594b-46d8-aa21-eec99026115d"/*A*/,
+          "Type": "System.Single",
+          "Value": 0.41
+        },
+        {
+          "Id": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"/*Center*/,
+          "Type": "System.Numerics.Vector2",
+          "Value": {
+            "X": 2.84,
+            "Y": 3.0
+          }
+        },
+        {
+          "Id": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"/*ShaderCode*/,
+          "Type": "System.String",
+          "Value": "float2 asp=float2(TargetSize)/TargetSize.y;\nfloat3 p=float3((uv-0.5)*asp,0);\np=p*B+float3(Center,A);\nc.xyz=curlNoise2(p)*0.5+0.5;\nc.a=1;\n"
+        },
+        {
+          "Id": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"/*B*/,
+          "Type": "System.Single",
+          "Value": 8.0
+        },
+        {
+          "Id": "c9a801ec-13fb-4ad4-b0cd-d125b5db500a"/*AdditionalCode*/,
+          "Type": "System.String",
+          "Value": "#include \"shared/noise-functions.hlsl\"\n\nfloat3 curlNoise2(float3 p)\n{\n  const float e = .1;\n  float3 dx = float3(e, 0.0, 0.0);\n  float3 dy = float3(0.0, e, 0.0);\n  float3 dz = float3(0.0, 0.0, e);\n\n  float3 p_x0 = snoiseVec3(p - dx);\n  float3 p_x1 = snoiseVec3(p + dx);\n  float3 p_y0 = snoiseVec3(p - dy);\n  float3 p_y1 = snoiseVec3(p + dy);\n  float3 p_z0 = snoiseVec3(p - dz);\n  float3 p_z1 = snoiseVec3(p + dz);\n\n  float x = p_y1.z - p_y0.z - p_z1.y + p_z0.y;\n  float y = p_z1.x - p_z0.x - p_x1.z + p_x0.z;\n  float z = p_x1.y - p_x0.y - p_y1.x + p_y0.x;\n\n  const float divisor = 1.0 / (2.0 * e);\n  return normalize(float3(x, y, z) * divisor);\n}"
+        }
+      ],
+      "Outputs": []
+    },
+    {
+      "Id": "fe7c9c52-844f-4338-8662-51a5c52bad27"/*Blend*/,
+      "SymbolId": "9f43f769-d32a-4f49-92ac-e0be3ba250cf",
+      "InputValues": [],
+      "Outputs": []
+    }
+  ],
+  "Connections": [
+    {
+      "SourceParentOrChildId": "799f9083-a102-49e1-82b8-ccc757f3d379",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "TargetSlotId": "c18cb083-0743-45ae-bb29-b2fa23803418"
+    },
+    {
+      "SourceParentOrChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0",
+      "SourceSlotId": "f5531ffb-dbde-45d3-af2a-bd90bcbf3710",
+      "TargetParentOrChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5",
+      "TargetSlotId": "2dc4d202-2ee5-4d4d-b1b2-234a0b21ab94"
+    },
+    {
+      "SourceParentOrChildId": "a351e265-3787-42e6-981c-ae0a55a8c1c9",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "470cf286-6c57-4b58-8753-46da132d6ad6",
+      "SourceSlotId": "dd9d8718-addc-49b1-bd33-aac22b366f94",
+      "TargetParentOrChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5",
+      "TargetSlotId": "8c3ffefe-8721-4dde-b252-22eb8be02d3f"
+    },
+    {
+      "SourceParentOrChildId": "d1606023-2bdc-4ab2-a8b6-da2f08cca3e4",
+      "SourceSlotId": "0e45c596-c80f-4927-941f-e3199401aa10",
+      "TargetParentOrChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5",
+      "TargetSlotId": "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12"
+    },
+    {
+      "SourceParentOrChildId": "97ed6799-a5eb-49a7-abff-760989a12120",
+      "SourceSlotId": "0e45c596-c80f-4927-941f-e3199401aa10",
+      "TargetParentOrChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5",
+      "TargetSlotId": "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12"
+    },
+    {
+      "SourceParentOrChildId": "78765ddb-730d-4538-947f-0895a318b297",
+      "SourceSlotId": "dc71f39f-3fba-4fc6-b8ef-ce57c82bf78e",
+      "TargetParentOrChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5",
+      "TargetSlotId": "b898c5a9-1c4b-4958-a7c1-01c27da10f6a"
+    },
+    {
+      "SourceParentOrChildId": "94869a8f-d975-4e11-b58a-75cb24722523",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5",
+      "TargetSlotId": "e63cf24c-0e01-47d4-9532-18261310315e"
+    },
+    {
+      "SourceParentOrChildId": "43212e58-a045-4aa7-ba5a-d3de218030dc",
+      "SourceSlotId": "3f8b20a7-c8b8-45ab-86a1-0efcd927358e",
+      "TargetParentOrChildId": "227072ad-e81b-4503-9179-daac5f0bdb42",
+      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    },
+    {
+      "SourceParentOrChildId": "520660a9-53bb-490a-9add-4dd43852e509",
+      "SourceSlotId": "ae4addf0-08cf-4b25-9515-4fef9359d183",
+      "TargetParentOrChildId": "270e4d1a-921b-46ce-8d1e-578e07b09eb0",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "7b469aed-af76-4f64-a86f-2fb34f5c1acb",
+      "SourceSlotId": "54831ac3-d747-4cdf-9520-3cfd651158bf",
+      "TargetParentOrChildId": "270e4d1a-921b-46ce-8d1e-578e07b09eb0",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "0fba74b7-c888-4996-998f-dedb8c6d05fe",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "2fdf8ebd-40fb-4c75-9ae1-4964ab4e5700",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "b1e180a9-646d-4b4b-a4ab-8563474110a2",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "2fdf8ebd-40fb-4c75-9ae1-4964ab4e5700",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "e03a5d28-d6ee-4a34-886f-abf8f3ceac48",
+      "SourceSlotId": "0e45c596-c80f-4927-941f-e3199401aa10",
+      "TargetParentOrChildId": "2fdf8ebd-40fb-4c75-9ae1-4964ab4e5700",
+      "TargetSlotId": "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12"
+    },
+    {
+      "SourceParentOrChildId": "853081ae-5bd4-4145-83f0-c3d3c1e2a9ee",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "2fdf8ebd-40fb-4c75-9ae1-4964ab4e5700",
+      "TargetSlotId": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"
+    },
+    {
+      "SourceParentOrChildId": "7c3c1327-2e55-4356-862d-b214bd0e91dd",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "3bd6be50-324f-40f7-b709-b267d0ab503b",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "fe7c9c52-844f-4338-8662-51a5c52bad27",
+      "SourceSlotId": "536fae14-b814-498c-a6b4-07775de36991",
+      "TargetParentOrChildId": "3bd6be50-324f-40f7-b709-b267d0ab503b",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "7cd0a1f7-ce45-4333-ab91-8ed13a42a15a",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "3bd6be50-324f-40f7-b709-b267d0ab503b",
+      "TargetSlotId": "60bdd684-8005-4576-b09b-1b5d6124da1d"
+    },
+    {
+      "SourceParentOrChildId": "b704984d-cb1c-4703-b1e0-df79e4fdf7d5",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "3bd6be50-324f-40f7-b709-b267d0ab503b",
+      "TargetSlotId": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"
+    },
+    {
+      "SourceParentOrChildId": "f8fa0591-10e4-4b29-813e-a6874ee77073",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "3bd6be50-324f-40f7-b709-b267d0ab503b",
+      "TargetSlotId": "db522fd4-5cfc-49f6-9983-02ec0dd6090a"
+    },
+    {
+      "SourceParentOrChildId": "b1f420b0-1671-4f42-8327-d07e6f8b75de",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "418b1206-09d2-4a5d-82dd-7acd9a97ea2f",
+      "TargetSlotId": "e63cf24c-0e01-47d4-9532-18261310315e"
+    },
+    {
+      "SourceParentOrChildId": "abcfabd0-ed2a-47c6-9f4b-c220e846e41c",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "5361507f-bbfd-4a3d-a07e-53f706cd50cd",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "563fb13f-67a8-4576-a6cb-15e7abec997a",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "5361507f-bbfd-4a3d-a07e-53f706cd50cd",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "dfe6b047-b50c-45fa-a471-51b140a7bf40",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "5361507f-bbfd-4a3d-a07e-53f706cd50cd",
+      "TargetSlotId": "60bdd684-8005-4576-b09b-1b5d6124da1d"
+    },
+    {
+      "SourceParentOrChildId": "05b5391b-1ef0-4901-a4d4-665a52ec659b",
+      "SourceSlotId": "fae78369-9db9-4b00-94f2-89e7581db426",
+      "TargetParentOrChildId": "6296b80f-0d34-4536-8d85-552cc1855e35",
+      "TargetSlotId": "980ef785-6ae2-44d1-803e-febfc75791c5"
+    },
+    {
+      "SourceParentOrChildId": "c16fd9b2-69a2-4a63-a173-af762d5f91ec",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "6675e7ce-737a-4126-9658-3b12b78951e6",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "b6e53ef3-1935-4e5b-a309-4aaf2bd183a8",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "6ed76894-3875-4220-9acd-d1b664f76746",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "b1e180a9-646d-4b4b-a4ab-8563474110a2",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "6ed76894-3875-4220-9acd-d1b664f76746",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "1cb7100c-0052-460a-8df9-81d7486f3c7d",
+      "SourceSlotId": "0e45c596-c80f-4927-941f-e3199401aa10",
+      "TargetParentOrChildId": "6ed76894-3875-4220-9acd-d1b664f76746",
+      "TargetSlotId": "8ea35e89-137a-4cb3-b26d-ba6bd9e5ce12"
+    },
+    {
+      "SourceParentOrChildId": "16ff6272-3eff-4f08-a1fb-6f1aa1b4d7d1",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "6ed76894-3875-4220-9acd-d1b664f76746",
+      "TargetSlotId": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"
+    },
+    {
+      "SourceParentOrChildId": "1611ddeb-6158-4d48-9110-3d7db9b7186a",
+      "SourceSlotId": "d7605a96-adc6-4a2b-9ba4-33adef3b7f4c",
+      "TargetParentOrChildId": "6f14f3e8-ecd8-4e8a-99a1-b5406cbe0fd6",
+      "TargetSlotId": "3f5abde2-66e1-4b04-9bff-5a19a58aab86"
+    },
+    {
+      "SourceParentOrChildId": "97c5f3d0-29e8-4f33-9892-19ce1e34c978",
+      "SourceSlotId": "ae4addf0-08cf-4b25-9515-4fef9359d183",
+      "TargetParentOrChildId": "6f14f3e8-ecd8-4e8a-99a1-b5406cbe0fd6",
+      "TargetSlotId": "aaba1602-e7a1-4b48-81d4-9d7b2b3aa8b1"
+    },
+    {
+      "SourceParentOrChildId": "1504210f-88b2-4928-b600-b157cfd1476f",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "729d44cd-11dc-40b6-bc6e-066484aab39b",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "fe7c9c52-844f-4338-8662-51a5c52bad27",
+      "SourceSlotId": "536fae14-b814-498c-a6b4-07775de36991",
+      "TargetParentOrChildId": "729d44cd-11dc-40b6-bc6e-066484aab39b",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "0e697437-0396-49f9-bfc8-03679a8d9e7a",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "729d44cd-11dc-40b6-bc6e-066484aab39b",
+      "TargetSlotId": "60bdd684-8005-4576-b09b-1b5d6124da1d"
+    },
+    {
+      "SourceParentOrChildId": "5cb28ad6-b4bc-4768-ba83-e09cb28e16e6",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "729d44cd-11dc-40b6-bc6e-066484aab39b",
+      "TargetSlotId": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"
+    },
+    {
+      "SourceParentOrChildId": "735bf1c0-df83-42b6-8aae-a19aa3ed0cf3",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "729d44cd-11dc-40b6-bc6e-066484aab39b",
+      "TargetSlotId": "db522fd4-5cfc-49f6-9983-02ec0dd6090a"
+    },
+    {
+      "SourceParentOrChildId": "b9b8de62-ae21-4672-b782-a91189992843",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "78765ddb-730d-4538-947f-0895a318b297",
+      "TargetSlotId": "d5afa102-2f88-431e-9cd4-af91e41f88f6"
+    },
+    {
+      "SourceParentOrChildId": "84a2e769-bc6c-4695-b944-ce518353da56",
+      "SourceSlotId": "f5531ffb-dbde-45d3-af2a-bd90bcbf3710",
+      "TargetParentOrChildId": "799f9083-a102-49e1-82b8-ccc757f3d379",
+      "TargetSlotId": "2dc4d202-2ee5-4d4d-b1b2-234a0b21ab94"
+    },
+    {
+      "SourceParentOrChildId": "bee3c8a7-899f-49a4-99ae-0357d7ab7554",
+      "SourceSlotId": "f5531ffb-dbde-45d3-af2a-bd90bcbf3710",
+      "TargetParentOrChildId": "799f9083-a102-49e1-82b8-ccc757f3d379",
+      "TargetSlotId": "2dc4d202-2ee5-4d4d-b1b2-234a0b21ab94"
+    },
+    {
+      "SourceParentOrChildId": "c2630922-354e-4655-8d29-285604bc24ea",
+      "SourceSlotId": "7a4c4feb-be2f-463e-96c6-cd9a6bad77a2",
+      "TargetParentOrChildId": "799f9083-a102-49e1-82b8-ccc757f3d379",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "ef8d3108-5a53-43b1-97be-3325bc96e220",
+      "SourceSlotId": "dc71f39f-3fba-4fc6-b8ef-ce57c82bf78e",
+      "TargetParentOrChildId": "799f9083-a102-49e1-82b8-ccc757f3d379",
+      "TargetSlotId": "b898c5a9-1c4b-4958-a7c1-01c27da10f6a"
+    },
+    {
+      "SourceParentOrChildId": "a574f8d0-16ec-412f-b4bf-1d210398bfab",
+      "SourceSlotId": "dc71f39f-3fba-4fc6-b8ef-ce57c82bf78e",
+      "TargetParentOrChildId": "799f9083-a102-49e1-82b8-ccc757f3d379",
+      "TargetSlotId": "b898c5a9-1c4b-4958-a7c1-01c27da10f6a"
+    },
+    {
+      "SourceParentOrChildId": "cdded62e-6380-420b-a3fc-9a21960c8d0f",
+      "SourceSlotId": "7a4c4feb-be2f-463e-96c6-cd9a6bad77a2",
+      "TargetParentOrChildId": "799f9083-a102-49e1-82b8-ccc757f3d379",
+      "TargetSlotId": "e63cf24c-0e01-47d4-9532-18261310315e"
+    },
+    {
+      "SourceParentOrChildId": "a2939f70-cd4a-42b5-9337-e550f6cee3e8",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "79b61f85-27f8-4087-bba4-f2f5bbcd2166",
+      "TargetSlotId": "3aab9b12-1e02-4d7a-83b6-da1500a6bcbf"
+    },
+    {
+      "SourceParentOrChildId": "1005741b-ddec-4da5-9a60-3b96a53af1f3",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "7b469aed-af76-4f64-a86f-2fb34f5c1acb",
+      "TargetSlotId": "3aab9b12-1e02-4d7a-83b6-da1500a6bcbf"
+    },
+    {
+      "SourceParentOrChildId": "4890bfd3-47e4-4d7b-9c02-177530e1b0db",
+      "SourceSlotId": "ae4addf0-08cf-4b25-9515-4fef9359d183",
+      "TargetParentOrChildId": "7b469aed-af76-4f64-a86f-2fb34f5c1acb",
+      "TargetSlotId": "6a786aa9-edf4-4363-9e34-0ddc7e763f0b"
+    },
+    {
+      "SourceParentOrChildId": "8cee3c58-1dc5-490f-a9c9-6d1002f02d32",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "0ec684a6-e48b-4185-9f4a-b6b5121a921d",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "db47f590-cf4b-447b-b0db-5f9efc8dbe36",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "64946e74-6f35-4bda-821c-f9283304d9b4",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "84bb4500-26e4-4172-b9b3-d53d63b0cb7d",
+      "SourceSlotId": "1cee5adb-8c3c-4575-bdd6-5669c04d55ce",
+      "TargetParentOrChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "84bb4500-26e4-4172-b9b3-d53d63b0cb7d",
+      "SourceSlotId": "305d321d-3334-476a-9fa3-4847912a4c58",
+      "TargetParentOrChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "c11dfd71-84b8-4681-8659-7926b3d236e0",
+      "SourceSlotId": "172dcbd2-a475-4514-8620-38f07a0ea4aa",
+      "TargetParentOrChildId": "820b11a9-cc8b-42f2-a77b-1c850206a506",
+      "TargetSlotId": "7a13b834-21e5-4cef-ad5b-23c3770ea763"
+    },
+    {
+      "SourceParentOrChildId": "d0247b50-18f7-4fa1-a12f-5c27393f3233",
+      "SourceSlotId": "8a65b34b-40be-4dbf-812c-d4c663464c7f",
+      "TargetParentOrChildId": "84a2e769-bc6c-4695-b944-ce518353da56",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "5858e6d9-a533-48e6-a0b0-cf60debc3b4c",
+      "SourceSlotId": "6276597c-580f-4aa4-b066-2735c415fd7c",
+      "TargetParentOrChildId": "84bb4500-26e4-4172-b9b3-d53d63b0cb7d",
+      "TargetSlotId": "36f14238-5bb8-4521-9533-f4d1e8fb802b"
+    },
+    {
+      "SourceParentOrChildId": "79b61f85-27f8-4087-bba4-f2f5bbcd2166",
+      "SourceSlotId": "54831ac3-d747-4cdf-9520-3cfd651158bf",
+      "TargetParentOrChildId": "862952a2-0074-462d-85de-ba65fb756145",
+      "TargetSlotId": "e63cf24c-0e01-47d4-9532-18261310315e"
+    },
+    {
+      "SourceParentOrChildId": "87ad5a77-11f3-429b-bc1b-689849ec9cec",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "8985c6dd-f497-496d-8ccd-2549e25970be",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "6977a3c8-63f9-4eaa-9ac3-85f6ea70a4dd",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "8985c6dd-f497-496d-8ccd-2549e25970be",
+      "TargetSlotId": "60bdd684-8005-4576-b09b-1b5d6124da1d"
+    },
+    {
+      "SourceParentOrChildId": "6675e7ce-737a-4126-9658-3b12b78951e6",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "8985c6dd-f497-496d-8ccd-2549e25970be",
+      "TargetSlotId": "e63cf24c-0e01-47d4-9532-18261310315e"
+    },
+    {
+      "SourceParentOrChildId": "9665e9f3-8f6a-494b-afcc-a19950163db7",
+      "SourceSlotId": "3f8b20a7-c8b8-45ab-86a1-0efcd927358e",
+      "TargetParentOrChildId": "8f0f7586-73ea-4db5-8792-2c99bf51b209",
+      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    },
+    {
+      "SourceParentOrChildId": "fe7c9c52-844f-4338-8662-51a5c52bad27",
+      "SourceSlotId": "536fae14-b814-498c-a6b4-07775de36991",
+      "TargetParentOrChildId": "9c50a330-12c5-4275-915c-c5884b3544e3",
+      "TargetSlotId": "73afdd61-dd59-4018-a473-025272deab93"
+    },
+    {
+      "SourceParentOrChildId": "8f0f7586-73ea-4db5-8792-2c99bf51b209",
+      "SourceSlotId": "7a4c4feb-be2f-463e-96c6-cd9a6bad77a2",
+      "TargetParentOrChildId": "a574f8d0-16ec-412f-b4bf-1d210398bfab",
+      "TargetSlotId": "d5afa102-2f88-431e-9cd4-af91e41f88f6"
+    },
+    {
+      "SourceParentOrChildId": "3b45ce92-9527-4c15-bf46-1eb56b493d5b",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "b1e180a9-646d-4b4b-a4ab-8563474110a2",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "7086900d-a6b2-4e4f-a4ad-10a7a950d684",
+      "SourceSlotId": "97a91f72-1e40-412c-911e-70b142e16925",
+      "TargetParentOrChildId": "b1e180a9-646d-4b4b-a4ab-8563474110a2",
+      "TargetSlotId": "92fdfa08-e7da-4a71-9145-277b74c93729"
+    },
+    {
+      "SourceParentOrChildId": "820b11a9-cc8b-42f2-a77b-1c850206a506",
+      "SourceSlotId": "1368ab8e-d75e-429f-8ecd-0944f3ede9ab",
+      "TargetParentOrChildId": "b1f420b0-1671-4f42-8327-d07e6f8b75de",
+      "TargetSlotId": "b898c5a9-1c4b-4958-a7c1-01c27da10f6a"
+    },
+    {
+      "SourceParentOrChildId": "1008221d-295a-4866-85fe-9ce57a4dc2aa",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "b8ca8474-560f-4c7e-b485-0f3ee2c6f08f",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "6296b80f-0d34-4536-8d85-552cc1855e35",
+      "SourceSlotId": "cfb58526-0053-4bca-aa85-d83823efba96",
+      "TargetParentOrChildId": "bee3c8a7-899f-49a4-99ae-0357d7ab7554",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "6296b80f-0d34-4536-8d85-552cc1855e35",
+      "SourceSlotId": "2f8e90dd-ba03-43dc-82a2-8d817df45cc7",
+      "TargetParentOrChildId": "bee3c8a7-899f-49a4-99ae-0357d7ab7554",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "6296b80f-0d34-4536-8d85-552cc1855e35",
+      "SourceSlotId": "162bb4fe-3c59-45c2-97cc-ecba85c1b275",
+      "TargetParentOrChildId": "bee3c8a7-899f-49a4-99ae-0357d7ab7554",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "6296b80f-0d34-4536-8d85-552cc1855e35",
+      "SourceSlotId": "e1dede5f-6963-4bcc-aa12-abeb819bb5da",
+      "TargetParentOrChildId": "bee3c8a7-899f-49a4-99ae-0357d7ab7554",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
+    },
+    {
+      "SourceParentOrChildId": "3bd6be50-324f-40f7-b709-b267d0ab503b",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "c0debbb5-e51c-478c-a510-cbcffdef5555",
+      "TargetSlotId": "73afdd61-dd59-4018-a473-025272deab93"
+    },
+    {
+      "SourceParentOrChildId": "0c8091e6-556c-4441-8efa-d03f76351851",
+      "SourceSlotId": "ae4addf0-08cf-4b25-9515-4fef9359d183",
+      "TargetParentOrChildId": "c11dfd71-84b8-4681-8659-7926b3d236e0",
+      "TargetSlotId": "4dffb439-da81-477c-8100-34a9ba59b0ee"
+    },
+    {
+      "SourceParentOrChildId": "6f14f3e8-ecd8-4e8a-99a1-b5406cbe0fd6",
+      "SourceSlotId": "bea6aa18-e751-4ce7-b7d7-b7a026c8e019",
+      "TargetParentOrChildId": "c11dfd71-84b8-4681-8659-7926b3d236e0",
+      "TargetSlotId": "cb157c8e-98f1-46e9-b197-d17dea896e30"
+    },
+    {
+      "SourceParentOrChildId": "27ef94ac-d4b0-4a21-861b-6dc5716c9eac",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "c12886a4-3384-44a2-8e92-40d3314c9d1a",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "30a87eb9-b89d-407a-b7b6-91821381005d",
+      "SourceSlotId": "3f8b20a7-c8b8-45ab-86a1-0efcd927358e",
+      "TargetParentOrChildId": "c2630922-354e-4655-8d29-285604bc24ea",
+      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    },
+    {
+      "SourceParentOrChildId": "79b61f85-27f8-4087-bba4-f2f5bbcd2166",
+      "SourceSlotId": "54831ac3-d747-4cdf-9520-3cfd651158bf",
+      "TargetParentOrChildId": "c323214b-79c5-4ccb-96c8-880d45f0ca32",
+      "TargetSlotId": "e63cf24c-0e01-47d4-9532-18261310315e"
+    },
+    {
+      "SourceParentOrChildId": "2542e77e-540d-44af-b334-0b4e620f17e6",
+      "SourceSlotId": "3f8b20a7-c8b8-45ab-86a1-0efcd927358e",
+      "TargetParentOrChildId": "cdded62e-6380-420b-a3fc-9a21960c8d0f",
+      "TargetSlotId": "4da253b7-4953-439a-b03f-1d515a78bddf"
+    },
+    {
+      "SourceParentOrChildId": "75ba1de0-50b4-4368-be45-b1a1beaacb89",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "d1aa2c88-7dac-4ee1-b2f8-bbf389436e61",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "f22f1711-4fbf-4166-9087-2a1552eeaac9",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "d1aa2c88-7dac-4ee1-b2f8-bbf389436e61",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "17705b04-a8f5-469e-91c8-d405511e05d6",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "d1aa2c88-7dac-4ee1-b2f8-bbf389436e61",
+      "TargetSlotId": "60bdd684-8005-4576-b09b-1b5d6124da1d"
+    },
+    {
+      "SourceParentOrChildId": "37eecdbd-be04-4a06-87ed-ecff38e40043",
+      "SourceSlotId": "6276597c-580f-4aa4-b066-2735c415fd7c",
+      "TargetParentOrChildId": "d1aa2c88-7dac-4ee1-b2f8-bbf389436e61",
+      "TargetSlotId": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"
+    },
+    {
+      "SourceParentOrChildId": "bd5d133a-e2a1-458e-aa8d-75af79ad83e1",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "d1aa2c88-7dac-4ee1-b2f8-bbf389436e61",
+      "TargetSlotId": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"
+    },
+    {
+      "SourceParentOrChildId": "729d44cd-11dc-40b6-bc6e-066484aab39b",
+      "SourceSlotId": "12fcfd9e-1c2f-46fc-b570-83b93ec7d101",
+      "TargetParentOrChildId": "d93e7c9d-97f5-42a2-a58d-63adaca0852d",
+      "TargetSlotId": "73afdd61-dd59-4018-a473-025272deab93"
+    },
+    {
+      "SourceParentOrChildId": "227072ad-e81b-4503-9179-daac5f0bdb42",
+      "SourceSlotId": "7a4c4feb-be2f-463e-96c6-cd9a6bad77a2",
+      "TargetParentOrChildId": "ef8d3108-5a53-43b1-97be-3325bc96e220",
+      "TargetSlotId": "d5afa102-2f88-431e-9cd4-af91e41f88f6"
+    },
+    {
+      "SourceParentOrChildId": "27ef94ac-d4b0-4a21-861b-6dc5716c9eac",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "efa10689-4626-4a6a-9902-032a1106428d",
+      "TargetSlotId": "e63cf24c-0e01-47d4-9532-18261310315e"
+    },
+    {
+      "SourceParentOrChildId": "520660a9-53bb-490a-9add-4dd43852e509",
+      "SourceSlotId": "ae4addf0-08cf-4b25-9515-4fef9359d183",
+      "TargetParentOrChildId": "f18cef05-680f-4516-8bb7-6c3880b6a8e0",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "7b469aed-af76-4f64-a86f-2fb34f5c1acb",
+      "SourceSlotId": "54831ac3-d747-4cdf-9520-3cfd651158bf",
+      "TargetParentOrChildId": "f18cef05-680f-4516-8bb7-6c3880b6a8e0",
+      "TargetSlotId": "5f90f885-0ccc-4014-a921-dc710257835a"
+    },
+    {
+      "SourceParentOrChildId": "e0e2fd9c-2c40-431a-ba75-390d6258afe9",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "f22f1711-4fbf-4166-9087-2a1552eeaac9",
+      "TargetSlotId": "3d84725a-594b-46d8-aa21-eec99026115d"
+    },
+    {
+      "SourceParentOrChildId": "3f1e969f-1829-49b1-8614-9bb96527a1a0",
+      "SourceSlotId": "6276597c-580f-4aa4-b066-2735c415fd7c",
+      "TargetParentOrChildId": "f22f1711-4fbf-4166-9087-2a1552eeaac9",
+      "TargetSlotId": "674cabbd-cf31-46ac-9a1a-4f6bd727c977"
+    },
+    {
+      "SourceParentOrChildId": "03ae835b-8257-4c2d-844e-c1015343dc4e",
+      "SourceSlotId": "f83f1835-477e-4bb6-93f0-14bf273b8e94",
+      "TargetParentOrChildId": "f22f1711-4fbf-4166-9087-2a1552eeaac9",
+      "TargetSlotId": "b4895a95-5ff4-4583-9ec3-befcf0f7b18b"
+    },
+    {
+      "SourceParentOrChildId": "62c3bc21-9bdd-40ab-83bf-a768c3b3fc3a",
+      "SourceSlotId": "e0c4fedd-5c2f-46c8-b67d-5667435fb037",
+      "TargetParentOrChildId": "fe7c9c52-844f-4338-8662-51a5c52bad27",
+      "TargetSlotId": "abaa52e9-7d3d-4ae5-89d2-5251f61e5392"
+    },
+    {
+      "SourceParentOrChildId": "a9792082-4c97-493e-a5b2-40bde33395fb",
+      "SourceSlotId": "b882de23-5b94-4791-af13-e195211cffb3",
+      "TargetParentOrChildId": "fe7c9c52-844f-4338-8662-51a5c52bad27",
+      "TargetSlotId": "c7c524cf-e31e-4bac-8f77-58bd61b337de"
+    }
+  ]
+}

--- a/Operators/examples/lib/image/use/CustomPixelShaderExample.t3ui
+++ b/Operators/examples/lib/image/use/CustomPixelShaderExample.t3ui
@@ -1,0 +1,940 @@
+{
+  "Id": "af263c08-4f22-45a4-ad8c-caeb813c237b"/*CustomPixelShaderExample*/,
+  "Description": "",
+  "InputUis": [],
+  "SymbolChildUis": [
+    {
+      "ChildId": "03ae835b-8257-4c2d-844e-c1015343dc4e"/*scale*/,
+      "Position": {
+        "X": -110.987366,
+        "Y": 704.62756
+      }
+    },
+    {
+      "ChildId": "05b5391b-1ef0-4901-a4d4-665a52ec659b"/*Color*/,
+      "Position": {
+        "X": 1021.8426,
+        "Y": 1102.1212
+      }
+    },
+    {
+      "ChildId": "099ca1ee-8496-4ac4-a899-da0cf7acada5"/*CustomPixelShader*/,
+      "Position": {
+        "X": 1579.667,
+        "Y": 1655.0941
+      }
+    },
+    {
+      "ChildId": "0c8091e6-556c-4441-8efa-d03f76351851"/*AnimValue*/,
+      "Position": {
+        "X": -100.26511,
+        "Y": 2328.7068
+      }
+    },
+    {
+      "ChildId": "0e697437-0396-49f9-bfc8-03679a8d9e7a"/*ValGain*/,
+      "Position": {
+        "X": 140.69647,
+        "Y": 358.4857
+      }
+    },
+    {
+      "ChildId": "0ec684a6-e48b-4185-9f4a-b6b5121a921d"/*BlendAB*/,
+      "Position": {
+        "X": 1045.9932,
+        "Y": 1890.1895
+      }
+    },
+    {
+      "ChildId": "0fba74b7-c888-4996-998f-dedb8c6d05fe"/*mipbias*/,
+      "Position": {
+        "X": 1223.9211,
+        "Y": 19.961426
+      }
+    },
+    {
+      "ChildId": "1005741b-ddec-4da5-9a60-3b96a53af1f3"/*LoadImage*/,
+      "Position": {
+        "X": 341.07855,
+        "Y": 1915.6937
+      }
+    },
+    {
+      "ChildId": "1008221d-295a-4866-85fe-9ce57a4dc2aa"/*LoadImage*/,
+      "Position": {
+        "X": -113.23828,
+        "Y": 1940.8438
+      }
+    },
+    {
+      "ChildId": "1504210f-88b2-4928-b600-b157cfd1476f"/*StretchAngle*/,
+      "Position": {
+        "X": 140.69647,
+        "Y": 288.4857
+      }
+    },
+    {
+      "ChildId": "1611ddeb-6158-4d48-9110-3d7db9b7186a"/*RadialPoints*/,
+      "Position": {
+        "X": 39.734894,
+        "Y": 2188.7068
+      }
+    },
+    {
+      "ChildId": "16ff6272-3eff-4f08-a1fb-6f1aa1b4d7d1"/*expscale*/,
+      "Position": {
+        "X": 1215.4177,
+        "Y": 252.52759
+      }
+    },
+    {
+      "ChildId": "17705b04-a8f5-469e-91c8-d405511e05d6"/*displace*/,
+      "Position": {
+        "X": 194.70697,
+        "Y": 860.1023
+      }
+    },
+    {
+      "ChildId": "1cb7100c-0052-460a-8df9-81d7486f3c7d"/*SamplerState*/,
+      "Position": {
+        "X": 1215.4177,
+        "Y": 287.5276
+      }
+    },
+    {
+      "ChildId": "227072ad-e81b-4503-9179-daac5f0bdb42"/*RenderTarget*/,
+      "Position": {
+        "X": 1147.6877,
+        "Y": 839.5477
+      }
+    },
+    {
+      "ChildId": "2542e77e-540d-44af-b334-0b4e620f17e6"/*G*/,
+      "Position": {
+        "X": 1007.68756,
+        "Y": 741.0808
+      }
+    },
+    {
+      "ChildId": "270e4d1a-921b-46ce-8d1e-578e07b09eb0"/*CustomPixelShader*/,
+      "Position": {
+        "X": 664.5513,
+        "Y": 2030.9634
+      }
+    },
+    {
+      "ChildId": "27ef94ac-d4b0-4a21-861b-6dc5716c9eac"/*LoadImage*/,
+      "Position": {
+        "X": -122.58536,
+        "Y": 1617.5215
+      }
+    },
+    {
+      "ChildId": "2fdf8ebd-40fb-4c75-9ae1-4964ab4e5700"/*CustomPixelShader*/,
+      "Position": {
+        "X": 1363.9211,
+        "Y": -15.038574
+      }
+    },
+    {
+      "ChildId": "30a87eb9-b89d-407a-b7b6-91821381005d"/*R*/,
+      "Position": {
+        "X": 1007.68756,
+        "Y": 685.1931
+      }
+    },
+    {
+      "ChildId": "37eecdbd-be04-4a06-87ed-ecff38e40043"/*offset*/,
+      "Position": {
+        "X": 194.70697,
+        "Y": 755.1023
+      }
+    },
+    {
+      "ChildId": "3b45ce92-9527-4c15-bf46-1eb56b493d5b"/*LoadImage*/,
+      "Position": {
+        "X": 904.1644,
+        "Y": -58.818237
+      }
+    },
+    {
+      "ChildId": "3bd6be50-324f-40f7-b709-b267d0ab503b"/*CustomPixelShader*/,
+      "Position": {
+        "X": 242.0791,
+        "Y": 30.23703
+      }
+    },
+    {
+      "ChildId": "3f1e969f-1829-49b1-8614-9bb96527a1a0"/*offset*/,
+      "Position": {
+        "X": -110.987366,
+        "Y": 634.62756
+      }
+    },
+    {
+      "ChildId": "418b1206-09d2-4a5d-82dd-7acd9a97ea2f"/*CustomPixelShader*/,
+      "Position": {
+        "X": 112.87634,
+        "Y": 2425.2744
+      }
+    },
+    {
+      "ChildId": "43212e58-a045-4aa7-ba5a-d3de218030dc"/*B*/,
+      "Position": {
+        "X": 1007.68756,
+        "Y": 839.5477
+      }
+    },
+    {
+      "ChildId": "470cf286-6c57-4b58-8753-46da132d6ad6"/*String*/,
+      "Position": {
+        "X": 1051.9465,
+        "Y": 1608.4655
+      }
+    },
+    {
+      "ChildId": "4890bfd3-47e4-4d7b-9c02-177530e1b0db"/*AnimValue*/,
+      "Position": {
+        "X": 325.41373,
+        "Y": 2002.9669
+      }
+    },
+    {
+      "ChildId": "520660a9-53bb-490a-9add-4dd43852e509"/*AnimValue*/,
+      "Position": {
+        "X": 493.2693,
+        "Y": 2054.545
+      }
+    },
+    {
+      "ChildId": "5361507f-bbfd-4a3d-a07e-53f706cd50cd"/*CustomPixelShader*/,
+      "Position": {
+        "X": 32.883728,
+        "Y": 1208.4784
+      }
+    },
+    {
+      "ChildId": "563fb13f-67a8-4576-a6cb-15e7abec997a"/*LoadImage*/,
+      "Position": {
+        "X": -107.11615,
+        "Y": 1208.4784
+      }
+    },
+    {
+      "ChildId": "5858e6d9-a533-48e6-a0b0-cf60debc3b4c"/*Position*/,
+      "Position": {
+        "X": 905.9932,
+        "Y": 1995.1895
+      }
+    },
+    {
+      "ChildId": "5cb28ad6-b4bc-4768-ba83-e09cb28e16e6"/*StretchScale*/,
+      "Position": {
+        "X": 140.69647,
+        "Y": 323.4857
+      }
+    },
+    {
+      "ChildId": "6296b80f-0d34-4536-8d85-552cc1855e35"/*Vector4Components*/,
+      "Position": {
+        "X": 1161.8425,
+        "Y": 1102.1212
+      }
+    },
+    {
+      "ChildId": "62c3bc21-9bdd-40ab-83bf-a768c3b3fc3a"/*LoadImage*/,
+      "Position": {
+        "X": -72.9895,
+        "Y": -68.24686
+      }
+    },
+    {
+      "ChildId": "64946e74-6f35-4bda-821c-f9283304d9b4"/*Temp*/,
+      "Position": {
+        "X": 1045.9932,
+        "Y": 1960.1895
+      }
+    },
+    {
+      "ChildId": "6675e7ce-737a-4126-9658-3b12b78951e6"/*CustomPixelShader*/,
+      "Position": {
+        "X": 447.64142,
+        "Y": 1172.2217
+      }
+    },
+    {
+      "ChildId": "6977a3c8-63f9-4eaa-9ac3-85f6ea70a4dd"/*Displace*/,
+      "Position": {
+        "X": 447.64142,
+        "Y": 1242.2217
+      }
+    },
+    {
+      "ChildId": "6ed76894-3875-4220-9acd-d1b664f76746"/*CustomPixelShader*/,
+      "Position": {
+        "X": 1355.4177,
+        "Y": 182.52734
+      }
+    },
+    {
+      "ChildId": "6f14f3e8-ecd8-4e8a-99a1-b5406cbe0fd6"/*AddNoise*/,
+      "Position": {
+        "X": 39.734894,
+        "Y": 2223.7068
+      }
+    },
+    {
+      "ChildId": "7086900d-a6b2-4e4f-a4ad-10a7a950d684"/*GenerateMips*/,
+      "Position": {
+        "X": 904.1644,
+        "Y": -23.818237
+      }
+    },
+    {
+      "ChildId": "729d44cd-11dc-40b6-bc6e-066484aab39b"/*CustomPixelShader*/,
+      "Position": {
+        "X": 280.69653,
+        "Y": 253.48569
+      }
+    },
+    {
+      "ChildId": "735bf1c0-df83-42b6-8aae-a19aa3ed0cf3"/*ValBias*/,
+      "Position": {
+        "X": 140.69647,
+        "Y": 393.4857
+      }
+    },
+    {
+      "ChildId": "75ba1de0-50b4-4368-be45-b1a1beaacb89"/*phase*/,
+      "Position": {
+        "X": 194.70697,
+        "Y": 790.1023
+      }
+    },
+    {
+      "ChildId": "78765ddb-730d-4538-947f-0895a318b297"/*SrvFromTexture2d*/,
+      "Position": {
+        "X": 1439.667,
+        "Y": 1760.0941
+      }
+    },
+    {
+      "ChildId": "799f9083-a102-49e1-82b8-ccc757f3d379"/*CustomPixelShader*/,
+      "Position": {
+        "X": 1454.5159,
+        "Y": 780.9291
+      }
+    },
+    {
+      "ChildId": "79b61f85-27f8-4087-bba4-f2f5bbcd2166"/*resize 64x64*/,
+      "Position": {
+        "X": 451.45822,
+        "Y": 1627.936
+      }
+    },
+    {
+      "ChildId": "7b469aed-af76-4f64-a86f-2fb34f5c1acb"/*TransformImage*/,
+      "Position": {
+        "X": 465.41373,
+        "Y": 1967.9669
+      }
+    },
+    {
+      "ChildId": "7c3c1327-2e55-4356-862d-b214bd0e91dd"/*HueOffset*/,
+      "Position": {
+        "X": 102.07904,
+        "Y": 65.23703
+      }
+    },
+    {
+      "ChildId": "7cd0a1f7-ce45-4333-ab91-8ed13a42a15a"/*SatGain*/,
+      "Position": {
+        "X": 102.07904,
+        "Y": 135.23709
+      }
+    },
+    {
+      "ChildId": "7eb1633c-fd4c-4a37-afad-b6fdb70f43d0"/*FloatsToBuffer*/,
+      "Position": {
+        "X": 1185.9932,
+        "Y": 1820.1895
+      }
+    },
+    {
+      "ChildId": "820b11a9-cc8b-42f2-a77b-1c850206a506"/*GetBufferComponents*/,
+      "Position": {
+        "X": 39.734894,
+        "Y": 2363.7068
+      }
+    },
+    {
+      "ChildId": "84a2e769-bc6c-4695-b944-ce518353da56"/*IntsToBuffer*/,
+      "Position": {
+        "X": 1228.8845,
+        "Y": 993.4169
+      }
+    },
+    {
+      "ChildId": "84bb4500-26e4-4172-b9b3-d53d63b0cb7d"/*Vector2Components*/,
+      "Position": {
+        "X": 1045.9932,
+        "Y": 1995.1895
+      }
+    },
+    {
+      "ChildId": "853081ae-5bd4-4145-83f0-c3d3c1e2a9ee"/*expscale*/,
+      "Position": {
+        "X": 1223.9211,
+        "Y": 54.961426
+      }
+    },
+    {
+      "ChildId": "862952a2-0074-462d-85de-ba65fb756145"/*stretch*/,
+      "Position": {
+        "X": 635.88306,
+        "Y": 1592.4644
+      }
+    },
+    {
+      "ChildId": "87ad5a77-11f3-429b-bc1b-689849ec9cec"/*LoadImage*/,
+      "Position": {
+        "X": 447.64142,
+        "Y": 1137.2217
+      }
+    },
+    {
+      "ChildId": "8985c6dd-f497-496d-8ccd-2549e25970be"/*CustomPixelShader*/,
+      "Position": {
+        "X": 587.6415,
+        "Y": 1137.2217
+      }
+    },
+    {
+      "ChildId": "8cee3c58-1dc5-490f-a9c9-6d1002f02d32"/*Scale*/,
+      "Position": {
+        "X": 1045.9932,
+        "Y": 1855.1895
+      }
+    },
+    {
+      "ChildId": "8f0f7586-73ea-4db5-8792-2c99bf51b209"/*RenderTarget*/,
+      "Position": {
+        "X": 1150.7927,
+        "Y": 884.79016
+      }
+    },
+    {
+      "ChildId": "94869a8f-d975-4e11-b58a-75cb24722523"/*LoadImage*/,
+      "Position": {
+        "X": 1283.3167,
+        "Y": 1700.4916
+      }
+    },
+    {
+      "ChildId": "9665e9f3-8f6a-494b-afcc-a19950163db7"/*A*/,
+      "Position": {
+        "X": 1010.79254,
+        "Y": 884.79016
+      }
+    },
+    {
+      "ChildId": "97c5f3d0-29e8-4f33-9892-19ce1e34c978"/*AnimValue*/,
+      "Position": {
+        "X": -100.26511,
+        "Y": 2258.7068
+      }
+    },
+    {
+      "ChildId": "97ed6799-a5eb-49a7-abff-760989a12120"/*Sampler2*/,
+      "Position": {
+        "X": 1375.2913,
+        "Y": 1910.2423
+      }
+    },
+    {
+      "ChildId": "9c50a330-12c5-4275-915c-c5884b3544e3"/*WaveForm*/,
+      "Position": {
+        "X": 359.59793,
+        "Y": -78.2439
+      }
+    },
+    {
+      "ChildId": "a2939f70-cd4a-42b5-9337-e550f6cee3e8"/*LoadImage*/,
+      "Position": {
+        "X": 311.45828,
+        "Y": 1627.936
+      }
+    },
+    {
+      "ChildId": "a351e265-3787-42e6-981c-ae0a55a8c1c9"/*LoadImage*/,
+      "Position": {
+        "X": 1283.3167,
+        "Y": 1657.019
+      }
+    },
+    {
+      "ChildId": "a574f8d0-16ec-412f-b4bf-1d210398bfab"/*SrvFromTexture2d*/,
+      "Position": {
+        "X": 1314.5159,
+        "Y": 885.9291
+      }
+    },
+    {
+      "ChildId": "a9792082-4c97-493e-a5b2-40bde33395fb"/*Blob*/,
+      "Position": {
+        "X": -72.9895,
+        "Y": -33.246857
+      }
+    },
+    {
+      "ChildId": "abcfabd0-ed2a-47c6-9f4b-c220e846e41c"/*phase*/,
+      "Position": {
+        "X": -107.11615,
+        "Y": 1243.4784
+      }
+    },
+    {
+      "ChildId": "b1e180a9-646d-4b4b-a4ab-8563474110a2"/*CustomPixelShader*/,
+      "Position": {
+        "X": 1044.1644,
+        "Y": -58.818237
+      }
+    },
+    {
+      "ChildId": "b1f420b0-1671-4f42-8327-d07e6f8b75de"/*CustomPixelShader*/,
+      "Position": {
+        "X": -86.13809,
+        "Y": 2428.0603
+      }
+    },
+    {
+      "ChildId": "b6e53ef3-1935-4e5b-a309-4aaf2bd183a8"/*miplevel*/,
+      "Position": {
+        "X": 1215.4177,
+        "Y": 217.52759
+      }
+    },
+    {
+      "ChildId": "b704984d-cb1c-4703-b1e0-df79e4fdf7d5"/*HueCycles*/,
+      "Position": {
+        "X": 102.07904,
+        "Y": 100.23703
+      }
+    },
+    {
+      "ChildId": "b8ca8474-560f-4c7e-b485-0f3ee2c6f08f"/*CustomPixelShader*/,
+      "Position": {
+        "X": 26.761719,
+        "Y": 1940.8438
+      }
+    },
+    {
+      "ChildId": "b9b8de62-ae21-4672-b782-a91189992843"/*LoadImage*/,
+      "Position": {
+        "X": 1283.3167,
+        "Y": 1755.7692
+      }
+    },
+    {
+      "ChildId": "bd5d133a-e2a1-458e-aa8d-75af79ad83e1"/*scale*/,
+      "Position": {
+        "X": 194.70697,
+        "Y": 825.1023
+      }
+    },
+    {
+      "ChildId": "bee3c8a7-899f-49a4-99ae-0357d7ab7554"/*FloatsToBuffer*/,
+      "Position": {
+        "X": 1301.8425,
+        "Y": 1067.1212
+      }
+    },
+    {
+      "ChildId": "c0debbb5-e51c-478c-a510-cbcffdef5555"/*WaveForm*/,
+      "Position": {
+        "X": 382.0791,
+        "Y": 30.23703
+      }
+    },
+    {
+      "ChildId": "c11dfd71-84b8-4681-8659-7926b3d236e0"/*RandomizePoints*/,
+      "Position": {
+        "X": 39.734894,
+        "Y": 2293.7068
+      }
+    },
+    {
+      "ChildId": "c12886a4-3384-44a2-8e92-40d3314c9d1a"/*CustomPixelShader*/,
+      "Position": {
+        "X": 92.302345,
+        "Y": 1590.7031
+      }
+    },
+    {
+      "ChildId": "c16fd9b2-69a2-4a63-a173-af762d5f91ec"/*phase*/,
+      "Position": {
+        "X": 307.64142,
+        "Y": 1207.2217
+      }
+    },
+    {
+      "ChildId": "c2630922-354e-4655-8d29-285604bc24ea"/*RenderTarget*/,
+      "Position": {
+        "X": 1147.6877,
+        "Y": 685.1931
+      }
+    },
+    {
+      "ChildId": "c323214b-79c5-4ccb-96c8-880d45f0ca32"/*fit height*/,
+      "Position": {
+        "X": 635.88306,
+        "Y": 1686.513
+      }
+    },
+    {
+      "ChildId": "cdded62e-6380-420b-a3fc-9a21960c8d0f"/*RenderTarget*/,
+      "Position": {
+        "X": 1147.6877,
+        "Y": 741.0808
+      }
+    },
+    {
+      "ChildId": "d0247b50-18f7-4fa1-a12f-5c27393f3233"/*AlphaGridSize*/,
+      "Position": {
+        "X": 1088.8845,
+        "Y": 993.4169
+      }
+    },
+    {
+      "ChildId": "d1606023-2bdc-4ab2-a8b6-da2f08cca3e4"/*CustomSampler*/,
+      "Position": {
+        "X": 1375.2913,
+        "Y": 1856.6996
+      }
+    },
+    {
+      "ChildId": "d1aa2c88-7dac-4ee1-b2f8-bbf389436e61"/*CustomPixelShader*/,
+      "Position": {
+        "X": 334.70697,
+        "Y": 720.1023
+      }
+    },
+    {
+      "ChildId": "d93e7c9d-97f5-42a2-a58d-63adaca0852d"/*WaveForm*/,
+      "Position": {
+        "X": 420.69653,
+        "Y": 253.48569
+      }
+    },
+    {
+      "ChildId": "db47f590-cf4b-447b-b0db-5f9efc8dbe36"/*BlendC*/,
+      "Position": {
+        "X": 1045.9932,
+        "Y": 1925.1895
+      }
+    },
+    {
+      "ChildId": "dfe6b047-b50c-45fa-a471-51b140a7bf40"/*Displace*/,
+      "Position": {
+        "X": -107.11615,
+        "Y": 1278.4784
+      }
+    },
+    {
+      "ChildId": "e03a5d28-d6ee-4a34-886f-abf8f3ceac48"/*SamplerState*/,
+      "Position": {
+        "X": 1223.9211,
+        "Y": 89.961426
+      }
+    },
+    {
+      "ChildId": "e0e2fd9c-2c40-431a-ba75-390d6258afe9"/*phase*/,
+      "Position": {
+        "X": -110.987366,
+        "Y": 669.62756
+      }
+    },
+    {
+      "ChildId": "ef8d3108-5a53-43b1-97be-3325bc96e220"/*SrvFromTexture2d*/,
+      "Position": {
+        "X": 1314.5159,
+        "Y": 850.9291
+      }
+    },
+    {
+      "ChildId": "efa10689-4626-4a6a-9902-032a1106428d"/*CustomPixelShader*/,
+      "Position": {
+        "X": 92.302345,
+        "Y": 1669.1919
+      }
+    },
+    {
+      "ChildId": "f18cef05-680f-4516-8bb7-6c3880b6a8e0"/*CustomPixelShader*/,
+      "Position": {
+        "X": 652.8614,
+        "Y": 1939.9897
+      }
+    },
+    {
+      "ChildId": "f22f1711-4fbf-4166-9087-2a1552eeaac9"/*CustomPixelShader*/,
+      "Position": {
+        "X": 29.012695,
+        "Y": 599.62756
+      }
+    },
+    {
+      "ChildId": "f8fa0591-10e4-4b29-813e-a6874ee77073"/*SatBias*/,
+      "Position": {
+        "X": 102.07904,
+        "Y": 170.23715
+      }
+    },
+    {
+      "ChildId": "fc753e82-4146-4a7b-96f9-3b377deeff3f"/*CustomPixelShader*/,
+      "Position": {
+        "X": 579.31464,
+        "Y": 610.62805
+      }
+    },
+    {
+      "ChildId": "fe7c9c52-844f-4338-8662-51a5c52bad27"/*Blend*/,
+      "Position": {
+        "X": 67.0105,
+        "Y": -68.24686
+      }
+    }
+  ],
+  "OutputUis": [
+    {
+      "OutputId": "c18cb083-0743-45ae-bb29-b2fa23803418"/*ColorBuffer*/,
+      "Position": {
+        "X": 1626.0115,
+        "Y": 783.65204
+      }
+    }
+  ],
+  "Annotations": [
+    {
+      "Id": "0cf5ab4b-08d3-4989-b531-b79df9bc836c",
+      "Title": "use more than two textures: send texture 3+ as SRV to ShaderResources, add its def to \"AdditionalCode\"; register starts at t2\nuse more variables: put into float or int buffers and send to ConstantBuffer, add its def to \"AdditionalCode\"; register starts at b2",
+      "Label": "advanced setup",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 881.96564,
+        "Y": 528.10364
+      },
+      "Size": {
+        "X": 957.6894,
+        "Y": 865.25256
+      }
+    },
+    {
+      "Id": "44073be8-e70f-42f9-b0bd-a028b8168855",
+      "Title": "if set to off, it will keep previous frame in backbuffer\nusing discard or alpha mask can update a region of texture or partially blend input on top of backbuffer",
+      "Label": "clear rendertarget",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 297.6413,
+        "Y": 1826.5607
+      },
+      "Size": {
+        "X": 506.90826,
+        "Y": 273.4392
+      }
+    },
+    {
+      "Id": "47340fc3-0a83-41b4-98dd-018569ba3ce7",
+      "Label": "color filter prototyping",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -152.34735,
+        "Y": -120.0
+      },
+      "Size": {
+        "X": 974.2557,
+        "Y": 582.07446
+      }
+    },
+    {
+      "Id": "62a69cab-dd7c-4006-abd8-3f79389af041",
+      "Label": "displacement prototyping",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -152.34735,
+        "Y": 1032.6218
+      },
+      "Size": {
+        "X": 974.2557,
+        "Y": 360.73438
+      }
+    },
+    {
+      "Id": "6c9264c1-11c9-43a7-8758-caaa978a4a9c",
+      "Label": "misc",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -152.34735,
+        "Y": 1460.9778
+      },
+      "Size": {
+        "X": 974.2557,
+        "Y": 1094.0222
+      }
+    },
+    {
+      "Id": "6e6519c4-b018-41c5-803d-fb3a112dbfb4",
+      "Label": "using shared noise functions",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -152.34735,
+        "Y": 528.10364
+      },
+      "Size": {
+        "X": 974.2557,
+        "Y": 455.96143
+      }
+    },
+    {
+      "Id": "78a33b95-74ef-4321-9a68-f40c4231d7ef",
+      "Title": "can be used for advanced setup\nShaderCode needs to contain entire shader\nAdditionalCode gets added on top in this case, use it for #includes or keep empty - can do includes in main shader string\n\nat this point it might be better to create a new symbol/node.. but this setup is still somewhat compact and can be shared via copypaste",
+      "Label": "Ignore Template",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 881.96564,
+        "Y": 1460.9778
+      },
+      "Size": {
+        "X": 957.6894,
+        "Y": 639.0222
+      }
+    },
+    {
+      "Id": "a5d3e49d-eaaf-4a3b-a3fc-e7c333c3797d",
+      "Title": "it can now read Center,A,B,C,D params and other resources defined in template",
+      "Label": "additional code inserted right above main ps function",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -131.78891,
+        "Y": 1826.5608
+      },
+      "Size": {
+        "X": 402.02292,
+        "Y": 273.4392
+      }
+    },
+    {
+      "Id": "a8d324fc-6596-41e8-8d1b-61483e2e5ef8",
+      "Label": "can read any StructuredBuffer via SRV input +def",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -131.78891,
+        "Y": 2135.2783
+      },
+      "Size": {
+        "X": 402.02292,
+        "Y": 373.8545
+      }
+    },
+    {
+      "Id": "e0427e74-efb1-46bb-ad83-b70f4f5d6687",
+      "Title": "stretching to fullscreen if first texture or resolution is not set\n",
+      "Label": "inherit resolution from first texture",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": -131.78891,
+        "Y": 1530.1602
+      },
+      "Size": {
+        "X": 402.02292,
+        "Y": 249.91162
+      }
+    },
+    {
+      "Id": "e6b15352-32d3-4c71-8d51-a1d5e528e66c",
+      "Title": "stretch to fullscreen or specified resolution",
+      "Label": "read 2nd texture without sampler/filtering",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 297.6413,
+        "Y": 1530.1602
+      },
+      "Size": {
+        "X": 506.90826,
+        "Y": 249.91162
+      }
+    },
+    {
+      "Id": "ead83df3-4dc7-4320-8fae-a3c28ef63ff8",
+      "Label": "generate mips, use custom sampler",
+      "Color": {
+        "X": 0.6,
+        "Y": 0.6,
+        "Z": 0.6,
+        "W": 1.0
+      },
+      "Position": {
+        "X": 881.96564,
+        "Y": -120.0
+      },
+      "Size": {
+        "X": 957.68933,
+        "Y": 582.07446
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adding second texture, rendertarget format etc; and few more inputs to make it more flexible (see example).

Only change to old behavior is that it was previously premultiplying rgba output by alpha channel (which is wrong imo), now blending is off by default, rgba values get written to texture with no modification.