### PR TITLE
Refactor path resolution and remove warning

### DIFF
--- a/Editor/Gui/Windows/AssetLib/AssetFolder.cs
+++ b/Editor/Gui/Windows/AssetLib/AssetFolder.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
@@ -43,9 +43,9 @@ internal sealed class AssetFolder
         FolderType = type;
 
         AliasPath = GetAliasPath();
-        if (!ResourceManager.TryResolveRelativePath(AliasPath, selectedInstance, out AbsolutePath, out _, isFolder: true))
+        if (!string.IsNullOrEmpty(AliasPath))
         {
-            Log.Warning($"Can't resolve folder path ? {AliasPath}");
+            ResourceManager.TryResolveRelativePath(AliasPath, selectedInstance, out AbsolutePath, out _, isFolder: true);
         }
         
         HashCode = AliasPath.GetHashCode();


### PR DESCRIPTION
The AssetFolder constructor was logging a warning whenever a folder path couldn't be resolved.

```Log.Warning($"Can't resolve folder path ? {AliasPath}");```

Problem

This is expected behavior for:
•	The root folder (__root__) which has an empty alias path
•	Virtual folder structures that don't map to physical directories
This caused log spam during normal operation.

Solution
•	Only attempt path resolution when AliasPath is not empty - everything else is already handled..