### PR TITLE
fix: crash upon output creation with timeClip enabled

### DIFF
--- a/Core/Operator/Slots/TimeClipSlot.cs
+++ b/Core/Operator/Slots/TimeClipSlot.cs
@@ -42,7 +42,7 @@ public sealed class TimeClipSlot<T> : Slot<T>, ITimeClipProvider, IOutputDataUse
 
     public void SetOutputData(IOutputData data)
     {
-        TimeClip = (TimeClip)data;
+        TimeClip = data as TimeClip ?? new TimeClip();
         TimeClip.Id = Parent.SymbolChildId;
         TimeClip.UsedForRegionMapping = Parent is not IPreventingTimeRemap;
     }


### PR DESCRIPTION
## reproducer

- in some custom operator, right-click, add output, fill in, enable "TimeClip"
- click "Add"
- tixl crash
- (if you reopen your project, the output is here and valid)

