### PR TITLE
Fixed launch profile - Re-added launchSettings.json

### DIFF
--- a/Editor/Properties/launchSettings.json
+++ b/Editor/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "t3": {
+      "commandName": "Project",
+      "nativeDebugging": false
+    }
+  }
+}


### PR DESCRIPTION
Fixed launch profile issue that was happening in rider

launchSettings.json was recently removed - re-added

<img width="278" height="46" alt="image" src="https://github.com/user-attachments/assets/fe344683-0af0-41d1-af00-e839c4d4f0ef" />
