### PR TITLE
AssetLibrary & SymbolLibrary: styling

### DIFF
--- a/Editor/Gui/Styling/Icons.cs
+++ b/Editor/Gui/Styling/Icons.cs
@@ -261,6 +261,7 @@ internal static class Icons
             new(Icon.FileGeometry, slotIndex: 113),
             new(Icon.FileShader, slotIndex: 114),
             new(Icon.FileT3Font, slotIndex: 115),
+            new(Icon.FileVector, slotIndex: 116),
             // Intentionally left black
             new(Icon.FileDocument, slotIndex: 117),
             new(Icon.ScrollLog, slotIndex: 118),
@@ -411,6 +412,7 @@ public enum Icon
     FileGeometry,
     FileShader,
     FileT3Font,
+    FileVector,
     ScrollLog,
     ClearLog,
     CopyToClipboard,

--- a/Editor/Gui/Windows/AssetLib/AssetHandling.cs
+++ b/Editor/Gui/Windows/AssetLib/AssetHandling.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using T3.Core.Resource.Assets;
 using T3.Editor.Gui.Styling;
@@ -119,12 +119,12 @@ internal static class AssetHandling
                                    ])
                                    {
                                        PrimaryOperators =
-                                           [
-                                               new
-                                                   Guid("e8d94dd7-eb54-42fe-a7b1-b43543dd457e"), // LoadSvg
+                                           [    
+                                               new Guid("d05739d3-f89d-488d-85d0-c0d115265b75"), // LoadSvgAsTexture2D
+                                               new Guid("e8d94dd7-eb54-42fe-a7b1-b43543dd457e"), // LoadSvg
                                            ],
                                        Color = UiColors.ColorForValues,
-                                       IconId = (uint)Icon.FileDocument,
+                                       IconId = (uint)Icon.FileVector,
                                    });
         AssetType.RegisterType(new AssetType("Text",
                                    [

--- a/Editor/Gui/Windows/AssetLib/AssetLibrary.Draw.cs
+++ b/Editor/Gui/Windows/AssetLib/AssetLibrary.Draw.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Runtime.CompilerServices;
 using ImGuiNET;
 using T3.Core.DataTypes.Vector;
@@ -261,7 +261,7 @@ internal sealed partial class AssetLibrary
         ImGui.PushID(asset.Id.GetHashCode());
         {
             var fade = !fileConsumerOpSelected
-                           ? 0.7f
+                           ? 1.0f
                            : fileConsumerOpIsCompatible
                                ? 1f
                                : 0.2f;
@@ -360,12 +360,18 @@ internal sealed partial class AssetLibrary
                 // Tooltip
                 {
                     var absolutePath = asset.FileSystemInfo?.FullName;
-                    ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(4, 4));
+                    var fileName = asset.FileSystemInfo?.Name ?? "Unknown";
+                    var path = absolutePath != null && fileName != null && absolutePath.EndsWith(fileName)
+                    ? absolutePath.Substring(0, absolutePath.Length - fileName.Length)
+                    : absolutePath;
+
+                    ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(4, 4)*T3Ui.UiScaleFactor);
+                    
                     ImGui.BeginTooltip();
-                    ImGui.PushTextWrapPos(ImGui.GetFontSize() * 25.0f);
+                    ImGui.PushTextWrapPos(ImGui.GetFontSize() * 50.0f);
                     ImGui.TextUnformatted($"""
-                                           Filesize: {asset.FileSize}
-                                           Path: {absolutePath}
+                                           File: {fileName} | {asset.FileSize} bytes
+                                           Path: {path}
                                            Time: {asset.FileSystemInfo?.LastWriteTime}
                                            """);
                     ImGui.PopTextWrapPos();
@@ -414,6 +420,10 @@ internal sealed partial class AssetLibrary
         var drawList = ImGui.GetWindowDrawList();
         var buttonMin = ImGui.GetItemRectMin();
         var buttonMax = ImGui.GetItemRectMax();
+        if (ImGui.IsItemHovered())
+        {
+            drawList.AddRectFilled(buttonMin, buttonMax, UiColors.BackgroundActive.Fade(0.5f), 5);
+        }
         if (isActive)
         {
             drawList.AddRect(buttonMin, buttonMax, UiColors.StatusActivated, 5);

--- a/Editor/Gui/Windows/SymbolLib/SymbolLibrary.cs
+++ b/Editor/Gui/Windows/SymbolLib/SymbolLibrary.cs
@@ -107,9 +107,10 @@ internal sealed class SymbolLibrary : Window
         {
             _libraryFiltering.DrawSymbolFilters();
         }
-
+        var textColor = UiColors.Text.Fade(0.8f);
+        ImGui.PushStyleColor(ImGuiCol.Text, textColor.Rgba);
         ImGui.BeginChild("scrolling", Vector2.Zero, false, ImGuiWindowFlags.NoBackground);
-        {
+        { 
             // Show filtered or full tree depending on filter/search state
             if (_libraryFiltering.AnyFilterActive)
             {
@@ -128,6 +129,7 @@ internal sealed class SymbolLibrary : Window
                 DrawFilteredList();
             }
         }
+        ImGui.PopStyleColor();
         ImGui.EndChild();
     }
 


### PR DESCRIPTION
<img width="781" height="323" alt="image" src="https://github.com/user-attachments/assets/18714b6c-a32d-483e-8539-61a479470981" />
Symbol Library:
- uses `UiColors.Text.Fade(0.8f)`

Asset Library: 
- drawing a background when hovering an assest
- the tooltip looks a bit better
- I've referenced the FileVector icon for .svg file 
<img width="283" height="81" alt="image" src="https://github.com/user-attachments/assets/0998455c-c402-474a-8882-bc7abc7b814c" />
- . svg drag and drop use [LoadSvgAsTexture2D] by default



