### PR TITLE
Add: [AssimpImport], [AssimpExport]

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -16,6 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AssimpNetter" Version="6.0.2.1" />
         <PackageReference Include="Delaunator" Version="1.0.11" />
         <PackageReference Include="JeremyAnsel.Media.Dds" Version="2.0.4" />
         <PackageReference Include="ManagedBass" Version="4.0.2" />

--- a/Operators/Lib/Lib.csproj
+++ b/Operators/Lib/Lib.csproj
@@ -100,6 +100,7 @@
     <ProjectReference Include="..\..\Logging\Logging.csproj" Private="false" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="AssimpNetter" Version="6.0.2.1" />
     <PackageReference Include="DirectShowLib.Standard" Version="2.1.0" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="8.1.1" />
     <PackageReference Include="System.ServiceModel.Http" Version="8.1.1" />

--- a/Operators/Lib/io/assimp/AssimpExport.cs
+++ b/Operators/Lib/io/assimp/AssimpExport.cs
@@ -1,0 +1,816 @@
+using Assimp;
+using SharpDX;
+using SharpDX.Direct3D11;
+using T3.Core.Rendering;
+using T3.Core.Utils;
+using Scene = Assimp.Scene;
+
+namespace Lib.io.assimp;
+
+/// <summary>
+///     Export 3D models and point clouds to various formats including OBJ, STL, PLY, and more.
+///     Supported formats depend on your Assimp build configuration.
+///     Files are automatically named with a counter (MeshName_001.ext, MeshName_002.ext, etc.)
+/// </summary>
+[Guid("F66C3CD9-B648-4E19-A564-D87AA48D6D88")]
+internal sealed class AssimpExport : Instance<AssimpExport>
+{
+    private const int DefaultExportFormat = 1; // OBJ (most widely supported)
+
+    [Output(Guid = "369771FD-4C3F-4877-B44E-D42B28702282")]
+    public readonly Slot<string> StatusMessage = new();
+
+    // Outputs
+    [Output(Guid = "7FDE5B8D-B541-43D3-8EC4-67037F47BF31")]
+    public readonly Slot<bool> Success = new();
+
+    [Output(Guid = "A1B2C3D4-E5F6-7890-ABCD-EF1234567890")]
+    public readonly Slot<string> SupportedFormats = new();
+
+    public AssimpExport()
+    {
+        Success.UpdateAction += Update;
+    }
+
+    #region Update Method
+    private void Update(EvaluationContext context)
+    {
+        // Query supported formats on first update
+        QuerySupportedFormatsIfNeeded();
+
+        // Handle counter reset
+        if (ResetCounter.GetValue(context))
+        {
+            _exportCounter = 1;
+            ResetCounter.SetTypedInputValue(false);
+            SetResult(true, "Export counter reset to 1");
+            return;
+        }
+
+        // Handle export triggers
+        var exportMeshTriggered = MathUtils.WasTriggered(ExportMesh.GetValue(context), ref _exportMeshTriggered);
+        var exportPointsTriggered = MathUtils.WasTriggered(ExportPoints.GetValue(context), ref _exportPointsTriggered);
+
+        if (exportMeshTriggered)
+        {
+            ExportMesh.SetTypedInputValue(false);
+            DoExport(context, ExportType.Mesh);
+        }
+        else if (exportPointsTriggered)
+        {
+            ExportPoints.SetTypedInputValue(false);
+            DoExport(context, ExportType.Points);
+        }
+        else
+        {
+            // Maintain last state
+            Success.Value = _lastSuccess;
+            StatusMessage.Value = _lastStatus;
+        }
+
+        // Update supported formats output
+        if (_supportedFormats.Count > 0)
+            SupportedFormats.Value = string.Join(", ", _supportedFormats.OrderBy(x => x));
+    }
+    #endregion
+
+    #region Export
+    private enum ExportType
+    {
+        Mesh,
+        Points
+    }
+
+    private void DoExport(EvaluationContext context, ExportType exportType)
+    {
+        // Validate folder path
+        var folderPath = FolderPath.GetValue(context);
+        if (string.IsNullOrWhiteSpace(folderPath))
+        {
+            SetResult(false, "Export folder path is empty");
+            return;
+        }
+
+        // Get and sanitize mesh name
+        var meshName = SanitizeFilename(MeshName.GetValue(context) ?? "mesh");
+
+        // Get file extension for selected format
+        var extension = GetFileExtension(context);
+        if (string.IsNullOrEmpty(extension))
+        {
+            SetResult(false, "Unknown export format");
+            return;
+        }
+
+        // Generate output path
+        var fullPath = BuildOutputPath(folderPath, meshName, extension);
+        if (string.IsNullOrEmpty(fullPath))
+        {
+            SetResult(false, "Failed to build output path");
+            return;
+        }
+
+        // Ensure output directory exists
+        if (!EnsureOutputDirectory(fullPath))
+            return;
+
+        // Get input data
+        if (!GetInputData(context, exportType, out var meshData, out var pointData))
+            return;
+
+        // Perform export
+        try
+        {
+            var scene = BuildScene(meshData, pointData, meshName, context);
+            if (scene == null)
+                return; // Error already set
+
+            if (ExportScene(scene, fullPath, context))
+            {
+                _exportCounter++;
+                SetResult(true, $"Exported: {Path.GetFileName(fullPath)}");
+            }
+            else
+            {
+                SetResult(false, "Export failed (Assimp error)");
+            }
+        }
+        catch (Exception ex)
+        {
+            SetResult(false, $"Export failed: {ex.Message}");
+        }
+    }
+
+    private bool GetInputData(EvaluationContext context, ExportType exportType, out MeshBuffers meshData, out BufferWithViews pointData)
+    {
+        meshData = null;
+        pointData = null;
+
+        if (exportType == ExportType.Mesh)
+        {
+            meshData = MeshData.GetValue(context);
+            if (meshData == null)
+            {
+                SetResult(false, "No mesh data connected");
+                return false;
+            }
+        }
+        else // ExportType.Points
+        {
+            pointData = Points.GetValue(context);
+            if (pointData == null)
+            {
+                SetResult(false, "No point data connected");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private string BuildOutputPath(string folderPath, string meshName, string extension)
+    {
+        try
+        {
+            var fileName = $"{meshName}_{_exportCounter:D3}{extension}";
+            return Path.IsPathRooted(folderPath)
+                       ? Path.Combine(folderPath, fileName)
+                       : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, folderPath, fileName);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"Failed to build output path: {ex.Message}", this);
+            return string.Empty;
+        }
+    }
+
+    private bool EnsureOutputDirectory(string fullPath)
+    {
+        var directory = Path.GetDirectoryName(fullPath);
+        if (string.IsNullOrEmpty(directory))
+            return true;
+
+        if (Directory.Exists(directory))
+            return true;
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+            Log.Debug($"Created output directory: {directory}", this);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            SetResult(false, $"Failed to create directory: {ex.Message}");
+            return false;
+        }
+    }
+
+    private Scene BuildScene(MeshBuffers meshData, BufferWithViews pointData, string meshName, EvaluationContext context)
+    {
+        var scene = new Scene();
+
+        if (meshData != null)
+        {
+            if (!BuildMeshScene(scene, meshData, meshName, context))
+                return null;
+        }
+        else if (pointData != null)
+        {
+            if (!BuildPointsScene(scene, pointData, meshName, context))
+                return null;
+        }
+        else
+        {
+            // Neither mesh nor point data - should not happen if GetInputData validated correctly
+            return null;
+        }
+
+        return scene;
+    }
+
+    private bool BuildMeshScene(Scene scene, MeshBuffers meshData, string meshName, EvaluationContext context)
+    {
+        var vertices = ReadVertexBuffer(meshData.VertexBuffer);
+        var indices = ReadIndexBuffer(meshData.IndicesBuffer);
+
+        if (vertices.Length == 0)
+        {
+            SetResult(false, "Mesh has no vertices");
+            return false;
+        }
+
+        if (indices == null || indices.Length == 0)
+        {
+            SetResult(false, "Mesh has no faces");
+            return false;
+        }
+
+        // Validate vertex data
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            var v = vertices[i];
+            // Check for NaN or infinity in position
+            if (float.IsNaN(v.Position.X) || float.IsInfinity(v.Position.X) ||
+                float.IsNaN(v.Position.Y) || float.IsInfinity(v.Position.Y) ||
+                float.IsNaN(v.Position.Z) || float.IsInfinity(v.Position.Z))
+            {
+                SetResult(false, $"Vertex {i} has invalid position");
+                return false;
+            }
+        }
+
+        // Validate face indices
+        for (var i = 0; i < indices.Length; i++)
+        {
+            var face = indices[i];
+            if (face.X < 0 || face.X >= vertices.Length ||
+                face.Y < 0 || face.Y >= vertices.Length ||
+                face.Z < 0 || face.Z >= vertices.Length)
+            {
+                SetResult(false, $"Face {i} has invalid indices");
+                return false;
+            }
+        }
+
+        // Apply vertex limit if set (> 0)
+        var maxVertices = MaxVertexCount.GetValue(context);
+        if (maxVertices > 0 && vertices.Length > maxVertices)
+        {
+            var limitedVertices = new PbrVertex[maxVertices];
+            Array.Copy(vertices, limitedVertices, maxVertices);
+            vertices = limitedVertices;
+
+            // Keep only faces that reference vertices within the limited range
+            var limitedIndicesList = new List<Int3>();
+            foreach (var face in indices)
+                if (face.X < maxVertices && face.Y < maxVertices && face.Z < maxVertices)
+                    limitedIndicesList.Add(face);
+
+            indices = limitedIndicesList.ToArray();
+
+            // Check if we still have faces after filtering
+            if (indices.Length == 0)
+            {
+                SetResult(false, "Mesh has no valid faces after vertex limit");
+                return false;
+            }
+        }
+
+        var assimpMesh = new Mesh(meshName, PrimitiveType.Triangle);
+        AddMeshVertices(assimpMesh, vertices);
+        AddMeshFaces(assimpMesh, indices);
+        AddMeshOptionalAttributes(assimpMesh, vertices);
+
+        scene.Meshes.Add(assimpMesh);
+        scene.RootNode = new Node("Root");
+        scene.RootNode.MeshIndices.Add(0);
+
+        return true;
+    }
+
+    private bool BuildPointsScene(Scene scene, BufferWithViews pointData, string meshName, EvaluationContext context)
+    {
+        var points = ReadPointBuffer(pointData);
+
+        if (points.Length == 0)
+        {
+            SetResult(false, "Point buffer is empty");
+            return false;
+        }
+
+        // Apply point limit if set (> 0)
+        var maxVertices = MaxVertexCount.GetValue(context);
+        if (maxVertices > 0 && points.Length > maxVertices)
+        {
+            var limitedPoints = new Point[maxVertices];
+            Array.Copy(points, limitedPoints, maxVertices);
+            points = limitedPoints;
+        }
+
+        var assimpMesh = new Mesh(meshName, PrimitiveType.Point);
+
+        for (var i = 0; i < points.Length; i++)
+        {
+            var p = points[i];
+            assimpMesh.Vertices.Add(new Vector3(p.Position.X, p.Position.Y, p.Position.Z));
+            assimpMesh.Normals.Add(new Vector3(0, 1, 0));
+            assimpMesh.VertexColorChannels[0].Add(new Vector4(p.Color.X, p.Color.Y, p.Color.Z, p.Color.W));
+            // Note: Point clouds don't have faces - vertices are the primitives
+        }
+
+        scene.Meshes.Add(assimpMesh);
+        scene.RootNode = new Node("Root");
+        scene.RootNode.MeshIndices.Add(0);
+
+        return true;
+    }
+
+    private static bool _formatsLogged;
+    private static readonly HashSet<string> _supportedFormats = new();
+
+    private bool ExportScene(Scene scene, string fullPath, EvaluationContext context)
+    {
+        var formatId = GetExportFormatId(context);
+        if (string.IsNullOrEmpty(formatId))
+        {
+            SetResult(false, "Invalid export format ID");
+            return false;
+        }
+
+        // Validate scene before export
+        if (scene.Meshes.Count == 0)
+        {
+            SetResult(false, "Scene has no meshes");
+            return false;
+        }
+
+        var mesh = scene.Meshes[0];
+        if (mesh.VertexCount == 0)
+        {
+            SetResult(false, "Mesh has no vertices");
+            return false;
+        }
+
+        // Validate scene integrity
+        if (!ValidateSceneForExport(mesh))
+            return false;
+
+        try
+        {
+            using var exporter = new AssimpContext();
+
+            // Check if format is supported
+            if (!_supportedFormats.Contains(formatId))
+            {
+                var allFormats = string.Join(", ", _supportedFormats.OrderBy(x => x));
+                SetResult(false, $"Format '{formatId}' is not supported. Available: {allFormats}");
+                return false;
+            }
+
+            ApplyExportOptions(exporter, formatId, context);
+
+            // Add additional pre-export validation
+            if (mesh.FaceCount == 0 && mesh.PrimitiveType != PrimitiveType.Point)
+            {
+                SetResult(false, "Mesh has no faces");
+                return false;
+            }
+
+            var result = exporter.ExportFile(scene, fullPath, formatId);
+            if (!result)
+                SetResult(false, $"Assimp export failed for format '{formatId}'");
+            return result;
+        }
+        catch (AccessViolationException)
+        {
+            SetResult(false, $"Native crash exporting to '{formatId}' - format may be unstable");
+            Log.Error($"Assimp native access violation for format '{formatId}'", this);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"Assimp export error for '{formatId}': {ex.Message}", this);
+            SetResult(false, $"Export failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private static void QuerySupportedFormatsIfNeeded()
+    {
+        if (_formatsLogged)
+            return;
+
+        try
+        {
+            using var exporter = new AssimpContext();
+            var formats = exporter.GetSupportedExportFormats();
+            _supportedFormats.Clear();
+            foreach (var format in formats)
+                _supportedFormats.Add(format.FormatId.ToLowerInvariant());
+            Log.Debug($"Assimp supported export formats: {string.Join(", ", _supportedFormats.OrderBy(x => x))}", typeof(AssimpExport));
+            _formatsLogged = true;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning($"Failed to query supported export formats: {ex.Message}", typeof(AssimpExport));
+        }
+    }
+
+    private bool ValidateSceneForExport(Mesh mesh)
+    {
+        // Check for invalid vertex data that could cause native crashes
+        for (var i = 0; i < mesh.VertexCount; i++)
+        {
+            var v = mesh.Vertices[i];
+            if (float.IsNaN(v.X) || float.IsInfinity(v.X) ||
+                float.IsNaN(v.Y) || float.IsInfinity(v.Y) ||
+                float.IsNaN(v.Z) || float.IsInfinity(v.Z))
+            {
+                SetResult(false, $"Invalid vertex data at index {i}");
+                return false;
+            }
+        }
+
+        // Check face indices are valid
+        if (mesh.HasFaces && mesh.FaceCount > 0)
+            for (var i = 0; i < mesh.FaceCount; i++)
+            {
+                var face = mesh.Faces[i];
+                foreach (var index in face.Indices)
+                    if (index < 0 || index >= mesh.VertexCount)
+                    {
+                        SetResult(false, $"Invalid face index {index} at face {i}");
+                        return false;
+                    }
+            }
+
+        return true;
+    }
+    #endregion
+
+    #region Mesh Data Helpers
+    private void AddMeshVertices(Mesh assimpMesh, PbrVertex[] vertices)
+    {
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            var v = vertices[i];
+            assimpMesh.Vertices.Add(new Vector3(v.Position.X, v.Position.Y, v.Position.Z));
+            assimpMesh.Normals.Add(new Vector3(v.Normal.X, v.Normal.Y, v.Normal.Z));
+            assimpMesh.TextureCoordinateChannels[0].Add(new Vector3(v.Texcoord.X, v.Texcoord.Y, 0));
+        }
+    }
+
+    private void AddMeshFaces(Mesh assimpMesh, Int3[] indices)
+    {
+        for (var i = 0; i < indices.Length; i++)
+        {
+            var idx = indices[i];
+            assimpMesh.Faces.Add(new Face(new[] { idx.X, idx.Y, idx.Z }));
+        }
+    }
+
+    private void AddMeshOptionalAttributes(Mesh assimpMesh, PbrVertex[] vertices)
+    {
+        var hasAnyTangents = false;
+        var hasAnyBitangents = false;
+        var hasAnyColors = false;
+
+        // Check which attributes are present
+        foreach (var v in vertices)
+        {
+            if (v.Tangent.LengthSquared() > 0.0001f)
+                hasAnyTangents = true;
+            if (v.Bitangent.LengthSquared() > 0.0001f)
+                hasAnyBitangents = true;
+            if (HasVertexColor(v))
+                hasAnyColors = true;
+        }
+
+        // Add attributes only if at least one vertex has them
+        foreach (var v in vertices)
+        {
+            if (hasAnyTangents)
+            {
+                if (v.Tangent.LengthSquared() > 0.0001f)
+                    assimpMesh.Tangents.Add(new Vector3(v.Tangent.X, v.Tangent.Y, v.Tangent.Z));
+                else
+                    assimpMesh.Tangents.Add(new Vector3(1, 0, 0));
+            }
+
+            if (hasAnyBitangents)
+            {
+                if (v.Bitangent.LengthSquared() > 0.0001f)
+                    assimpMesh.BiTangents.Add(new Vector3(v.Bitangent.X, v.Bitangent.Y, v.Bitangent.Z));
+                else
+                    assimpMesh.BiTangents.Add(new Vector3(0, 1, 0));
+            }
+
+            if (hasAnyColors)
+                // Vertex colors: Selection (R) and Texcoord2.Y (A)
+                assimpMesh.VertexColorChannels[0].Add(new Vector4(
+                                                                  v.Selection, v.Selection, v.Selection, v.Texcoord2.Y));
+        }
+    }
+
+    private static bool HasVertexColor(PbrVertex v)
+    {
+        return Math.Abs(v.Selection - 1.0f) > 0.001f || Math.Abs(v.Texcoord2.Y - 1.0f) > 0.001f;
+    }
+    #endregion
+
+    #region Buffer Reading
+    private PbrVertex[] ReadVertexBuffer(BufferWithViews bufferWithViews)
+    {
+        if (bufferWithViews?.Buffer == null)
+            return Array.Empty<PbrVertex>();
+
+        var device = ResourceManager.Device;
+        var d3dContext = device.ImmediateContext;
+        var desc = bufferWithViews.Buffer.Description;
+        var vertexCount = desc.SizeInBytes / PbrVertex.Stride;
+
+        var stagingDesc = new BufferDescription
+                              {
+                                  SizeInBytes = desc.SizeInBytes,
+                                  Usage = ResourceUsage.Staging,
+                                  BindFlags = BindFlags.None,
+                                  CpuAccessFlags = CpuAccessFlags.Read,
+                                  OptionFlags = ResourceOptionFlags.BufferStructured,
+                                  StructureByteStride = desc.StructureByteStride
+                              };
+
+        using var staging = new Buffer(device, stagingDesc);
+        d3dContext.CopyResource(bufferWithViews.Buffer, staging);
+
+        var dataBox = d3dContext.MapSubresource(staging, 0, MapMode.Read, MapFlags.None);
+        try
+        {
+            using var stream = new DataStream(dataBox.DataPointer, dataBox.RowPitch, true, false);
+            return stream.ReadRange<PbrVertex>(vertexCount).ToArray();
+        }
+        finally
+        {
+            if (dataBox.DataPointer != IntPtr.Zero)
+                d3dContext.UnmapSubresource(staging, 0);
+        }
+    }
+
+    private Int3[] ReadIndexBuffer(BufferWithViews bufferWithViews)
+    {
+        if (bufferWithViews?.Buffer == null)
+            return Array.Empty<Int3>();
+
+        var device = ResourceManager.Device;
+        var d3dContext = device.ImmediateContext;
+        var desc = bufferWithViews.Buffer.Description;
+        var indexCount = desc.SizeInBytes / (3 * 4);
+
+        var stagingDesc = new BufferDescription
+                              {
+                                  SizeInBytes = desc.SizeInBytes,
+                                  Usage = ResourceUsage.Staging,
+                                  BindFlags = BindFlags.None,
+                                  CpuAccessFlags = CpuAccessFlags.Read,
+                                  OptionFlags = ResourceOptionFlags.BufferStructured,
+                                  StructureByteStride = desc.StructureByteStride
+                              };
+
+        using var staging = new Buffer(device, stagingDesc);
+        d3dContext.CopyResource(bufferWithViews.Buffer, staging);
+
+        var dataBox = d3dContext.MapSubresource(staging, 0, MapMode.Read, MapFlags.None);
+        try
+        {
+            using var stream = new DataStream(dataBox.DataPointer, dataBox.RowPitch, true, false);
+            return stream.ReadRange<Int3>(indexCount).ToArray();
+        }
+        finally
+        {
+            if (dataBox.DataPointer != IntPtr.Zero)
+                d3dContext.UnmapSubresource(staging, 0);
+        }
+    }
+
+    private Point[] ReadPointBuffer(BufferWithViews bufferWithViews)
+    {
+        if (bufferWithViews?.Buffer == null)
+            return Array.Empty<Point>();
+
+        var device = ResourceManager.Device;
+        var d3dContext = device.ImmediateContext;
+        var desc = bufferWithViews.Buffer.Description;
+        var pointCount = desc.SizeInBytes / Point.Stride;
+
+        var stagingDesc = new BufferDescription
+                              {
+                                  SizeInBytes = desc.SizeInBytes,
+                                  Usage = ResourceUsage.Staging,
+                                  BindFlags = BindFlags.None,
+                                  CpuAccessFlags = CpuAccessFlags.Read,
+                                  OptionFlags = ResourceOptionFlags.BufferStructured,
+                                  StructureByteStride = desc.StructureByteStride
+                              };
+
+        using var staging = new Buffer(device, stagingDesc);
+        d3dContext.CopyResource(bufferWithViews.Buffer, staging);
+
+        var dataBox = d3dContext.MapSubresource(staging, 0, MapMode.Read, MapFlags.None);
+        try
+        {
+            using var stream = new DataStream(dataBox.DataPointer, dataBox.RowPitch, true, false);
+            return stream.ReadRange<Point>(pointCount).ToArray();
+        }
+        finally
+        {
+            if (dataBox.DataPointer != IntPtr.Zero)
+                d3dContext.UnmapSubresource(staging, 0);
+        }
+    }
+    #endregion
+
+    #region Format Helpers
+    private enum ExportFormatPreset
+    {
+        Auto, // Falls back to OBJ if unsupported
+        Obj, // OBJ - Widely supported (mesh only)
+        Fbx, // FBX - May not be available in all builds
+        Gltf, // glTF 2.0 - Requires ASSIMP_BUILD_EXPORT_GLTF2
+        Glb, // GLB 2.0 - Requires ASSIMP_BUILD_EXPORT_GLTF2
+        Stl, // STL - Usually available (mesh only)
+        Ply, // PLY - Usually available
+        Collada, // Collada (DAE) - Requires ASSIMP_BUILD_EXPORT_COLLADA
+        ThreeDs, // 3DS - Legacy format, limited support
+        Custom // Use custom format ID
+    }
+
+    private enum GltfExportOptions
+    {
+        Default,
+        PrettyJson,
+        NoBuffersEmbedded
+    }
+
+    private string GetFileExtension(EvaluationContext context)
+    {
+        var format = (ExportFormatPreset)ExportFormat.GetValue(context);
+
+        if (format == ExportFormatPreset.Custom)
+        {
+            var customFormat = CustomFormat.GetValue(context);
+            return GetExtensionFromFormatId(customFormat);
+        }
+
+        return format switch
+                   {
+                       ExportFormatPreset.Obj     => ".obj",
+                       ExportFormatPreset.Fbx     => ".fbx",
+                       ExportFormatPreset.Gltf    => ".gltf",
+                       ExportFormatPreset.Glb     => ".glb",
+                       ExportFormatPreset.Stl     => ".stl",
+                       ExportFormatPreset.Ply     => ".ply",
+                       ExportFormatPreset.Collada => ".dae",
+                       ExportFormatPreset.ThreeDs => ".3ds",
+                       _                          => ".obj" // Auto defaults to OBJ (most widely supported)
+                   };
+    }
+
+    private string GetExtensionFromFormatId(string formatId)
+    {
+        if (string.IsNullOrEmpty(formatId))
+            return ".fbx";
+
+        return formatId.ToLowerInvariant() switch
+                   {
+                       "obj"     => ".obj",
+                       "fbx"     => ".fbx",
+                       "gltf2"   => ".gltf",
+                       "glb2"    => ".glb",
+                       "stl"     => ".stl",
+                       "ply"     => ".ply",
+                       "collada" => ".dae",
+                       "3ds"     => ".3ds",
+                       _         => ".fbx"
+                   };
+    }
+
+    private string GetExportFormatId(EvaluationContext context)
+    {
+        var format = (ExportFormatPreset)ExportFormat.GetValue(context);
+
+        if (format == ExportFormatPreset.Custom)
+            return CustomFormat.GetValue(context);
+
+        return format switch
+                   {
+                       ExportFormatPreset.Obj     => "obj",
+                       ExportFormatPreset.Fbx     => "fbx",
+                       ExportFormatPreset.Gltf    => "gltf2",
+                       ExportFormatPreset.Glb     => "glb2",
+                       ExportFormatPreset.Stl     => "stl",
+                       ExportFormatPreset.Ply     => "ply",
+                       ExportFormatPreset.Collada => "collada",
+                       ExportFormatPreset.ThreeDs => "3ds",
+                       _                          => "obj" // Auto defaults to OBJ (most widely supported)
+                   };
+    }
+
+    private void ApplyExportOptions(AssimpContext exporter, string formatId, EvaluationContext context)
+    {
+        // Note: AssimpNetter doesn't expose format-specific export options directly
+        // The GltfOptions enum is kept for future compatibility
+    }
+    #endregion
+
+    #region Utility Methods
+    /// <summary>
+    ///     Sanitizes a filename by removing invalid characters and trimming whitespace.
+    /// </summary>
+    private static string SanitizeFilename(string filename)
+    {
+        if (string.IsNullOrWhiteSpace(filename))
+            return "mesh";
+
+        // Remove invalid filename characters
+        var invalidChars = Path.GetInvalidFileNameChars();
+        var sanitized = string.Join("_", filename.Split(invalidChars));
+
+        // Trim whitespace and limit length
+        sanitized = sanitized.Trim();
+        if (sanitized.Length > 100)
+            sanitized = sanitized.Substring(0, 100);
+
+        return string.IsNullOrWhiteSpace(sanitized) ? "mesh" : sanitized;
+    }
+
+    private void SetResult(bool success, string message)
+    {
+        _lastSuccess = success;
+        _lastStatus = message;
+        Success.Value = success;
+        StatusMessage.Value = message;
+        Log.Debug($"AssimpExport: {message}", this);
+    }
+    #endregion
+
+    #region Fields and Inputs
+    private bool _exportMeshTriggered;
+    private bool _exportPointsTriggered;
+    private int _exportCounter = 1;
+    private bool _lastSuccess;
+    private string _lastStatus = "Ready";
+
+    [Input(Guid = "47F14471-1D6E-4BAD-A3CC-F372DDA4872C")]
+    public readonly InputSlot<MeshBuffers> MeshData = new();
+
+    [Input(Guid = "B0E70377-685C-44B1-8069-2F0C2A9DCBB2")]
+    public readonly InputSlot<BufferWithViews> Points = new();
+
+    [Input(Guid = "F784FE22-BA03-499C-BB4E-FE2DED8BF754")]
+    public readonly InputSlot<string> FolderPath = new("exports");
+
+    [Input(Guid = "20960269-69A9-4FF1-A3E7-395883521B06")]
+    public readonly InputSlot<bool> ExportMesh = new();
+
+    [Input(Guid = "5E6F7A8B-9C1D-2E3F-4A5B-6C7D8E9F0A1B")]
+    public readonly InputSlot<bool> ExportPoints = new();
+
+    [Input(Guid = "E8C4F2A7-9B3D-4E1F-A5C6-7D8E9F0A1B2C", MappedType = typeof(ExportFormatPreset))]
+    public readonly InputSlot<int> ExportFormat = new(DefaultExportFormat);
+
+    [Input(Guid = "F3D5E8B2-7A4C-4F9E-B2D1-6E7F8A9C0B1D")]
+    public readonly InputSlot<string> CustomFormat = new();
+
+    [Input(Guid = "1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D", MappedType = typeof(GltfExportOptions))]
+    public readonly InputSlot<int> GltfOptions = new((int)GltfExportOptions.Default);
+
+    [Input(Guid = "2B3C4D5E-6F7A-8B9C-1D2E-3F4A5B6C7D8E")]
+    public readonly InputSlot<string> MeshName = new("mesh");
+
+    [Input(Guid = "3C4D5E6F-7A8B-9C1D-2E3F-4A5B6C7D8E9F")]
+    public readonly InputSlot<bool> ResetCounter = new();
+
+    [Input(Guid = "4D5E6F7A-8B9C-1D2E-3F4A-6C7D8E9F0A1B")]
+    public readonly InputSlot<int> MaxVertexCount = new(0);
+    #endregion
+}

--- a/Operators/Lib/io/assimp/AssimpExport.t3
+++ b/Operators/Lib/io/assimp/AssimpExport.t3
@@ -1,0 +1,51 @@
+{
+  "Id": "f66c3cd9-b648-4e19-a564-d87aa48d6d88"/*AssimpExport*/,
+  "Inputs": [
+    {
+      "Id": "47f14471-1d6e-4bad-a3cc-f372dda4872c"/*MeshData*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "b0e70377-685c-44b1-8069-2f0c2a9dcbb2"/*Points*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "f784fe22-ba03-499c-bb4e-fe2ded8bf754"/*FolderPath*/,
+      "DefaultValue": "exports"
+    },
+    {
+      "Id": "20960269-69a9-4ff1-a3e7-395883521b06"/*ExportMesh*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "5e6f7a8b-9c1d-2e3f-4a5b-6c7d8e9f0a1b"/*ExportPoints*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "e8c4f2a7-9b3d-4e1f-a5c6-7d8e9f0a1b2c"/*ExportFormat*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "f3d5e8b2-7a4c-4f9e-b2d1-6e7f8a9c0b1d"/*CustomFormat*/,
+      "DefaultValue": ""
+    },
+    {
+      "Id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"/*GltfOptions*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "2b3c4d5e-6f7a-8b9c-1d2e-3f4a5b6c7d8e"/*MeshName*/,
+      "DefaultValue": "mesh"
+    },
+    {
+      "Id": "3c4d5e6f-7a8b-9c1d-2e3f-4a5b6c7d8e9f"/*ResetCounter*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "4d5e6f7a-8b9c-1d2e-3f4a-6c7d8e9f0a1b"/*MaxVertexCount*/,
+      "DefaultValue": 0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/io/assimp/AssimpExport.t3ui
+++ b/Operators/Lib/io/assimp/AssimpExport.t3ui
@@ -1,0 +1,114 @@
+{
+  "Id": "f66c3cd9-b648-4e19-a564-d87aa48d6d88"/*AssimpExport*/,
+  "Description": "Export 3D models to 20+ formats including FBX, glTF, OBJ, Collada, STL, and more. Supports mesh data, point clouds, vertex colors, and tangents. Files are automatically named with a counter.",
+  "InputUis": [
+    {
+      "InputId": "47f14471-1d6e-4bad-a3cc-f372dda4872c"/*MeshData*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Description": "Mesh data to export including vertices, normals, tangents, bitangents, and UV coordinates."
+    },
+    {
+      "InputId": "b0e70377-685c-44b1-8069-2f0c2a9dcbb2"/*Points*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      },
+      "Description": "Point cloud data to export. Exports as point primitives with position and color information."
+    },
+    {
+      "InputId": "f784fe22-ba03-499c-bb4e-fe2ded8bf754"/*FolderPath*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 150.0
+      },
+      "Description": "Output folder path for exported files. Files are automatically named as MeshName_001.ext, MeshName_002.ext, etc.",
+      "Usage": "Directory"
+    },
+    {
+      "InputId": "20960269-69a9-4ff1-a3e7-395883521b06"/*ExportMesh*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 225.0
+      },
+      "Description": "Trigger button to export mesh data. Automatically increments the counter and saves to FolderPath/MeshName_XXX.ext."
+    },
+    {
+      "InputId": "5e6f7a8b-9c1d-2e3f-4a5b-6c7d8e9f0a1b"/*ExportPoints*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 300.0
+      },
+      "Description": "Trigger button to export point cloud data. Automatically increments the counter and saves to FolderPath/MeshName_XXX.ext."
+    },
+    {
+      "InputId": "e8c4f2a7-9b3d-4e1f-a5c6-7d8e9f0a1b2c"/*ExportFormat*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 375.0
+      },
+      "Description": "Export format preset. Determines the file extension and export options."
+    },
+    {
+      "InputId": "2b3c4d5e-6f7a-8b9c-1d2e-3f4a5b6c7d8e"/*MeshName*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 450.0
+      },
+      "Description": "Base name for exported files. Counter is appended automatically (e.g., 'mesh' becomes 'mesh_001.fbx')."
+    },
+    {
+      "InputId": "3c4d5e6f-7a8b-9c1d-2e3f-4a5b6c7d8e9f"/*ResetCounter*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 525.0
+      },
+      "Description": "Reset the export counter back to 1. Useful when starting a new export session."
+    },
+    {
+      "InputId": "4d5e6f7a-8b9c-1d2e-3f4a-6c7d8e9f0a1b"/*MaxVertexCount*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 600.0
+      },
+      "Description": "Maximum number of vertices/points to export (0 = no limit). Useful for reducing file size or testing."
+    },
+    {
+      "InputId": "f3d5e8b2-7a4c-4f9e-b2d1-6e7f8a9c0b1d"/*CustomFormat*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 675.0
+      },
+      "Description": "Custom Assimp format ID when ExportFormat is set to Custom. Examples: 'fbx', 'gltf2', 'obj', 'stl'."
+    },
+    {
+      "InputId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"/*GltfOptions*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 750.0
+      },
+      "Description": "glTF export options. Default: standard export; PrettyJson: readable JSON output; NoBuffersEmbedded: external buffer files."
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "7fde5b8d-b541-43d3-8ec4-67037f47bf31"/*Success*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 0.0
+      },
+      "Description": "True if the last export operation completed successfully."
+    },
+    {
+      "OutputId": "369771fd-4c3f-4877-b44e-d42b28702282"/*StatusMessage*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 75.0
+      },
+      "Description": "Status message from the last export operation. Shows the exported filename or error details."
+    }
+  ]
+}

--- a/Operators/Lib/io/assimp/AssimpImport.cs
+++ b/Operators/Lib/io/assimp/AssimpImport.cs
@@ -1,0 +1,605 @@
+using Assimp;
+using T3.Core.Rendering;
+using Scene = Assimp.Scene;
+
+namespace Lib.io.assimp;
+
+[Guid("E0B5B99D-C44F-434D-920D-422E88C75870")]
+internal sealed class AssimpImport : Instance<AssimpImport>
+{
+    private readonly BufferWithViews _indexBufferWithViews = new();
+    private readonly MeshBuffers _meshData = new();
+    private readonly BufferWithViews _pointBufferWithViews = new();
+
+    private readonly Resource<Scene> _sceneResource;
+    private readonly BufferWithViews _vertexBufferWithViews = new();
+
+    [Input(Guid = "9C5D0E4F-7A1B-5C9D-2E3F-3B4C5D6E7F8A", MappedType = typeof(AxisConversion))]
+    public readonly InputSlot<int> AxisConversionMode = new((int)AxisConversion.None);
+
+    [Output(Guid = "F6A7B8C9-1D2E-4F3B-4C5D-5E6F7A8B9C1D")]
+    public readonly Slot<Vector3> BoundsMax = new();
+
+    [Output(Guid = "E5F6A7B8-9C1D-4E2F-3B4C-4D5E6F7A8B9C")]
+    public readonly Slot<Vector3> BoundsMin = new();
+
+    [Output(Guid = "C3D4E5F6-7A8B-4C9D-1E2F-2B3C4D5E6F7A")]
+    public readonly Slot<int> FaceCount = new();
+
+    [Input(Guid = "B569D0CC-9F84-419C-A3DB-91406DF6A3F8")]
+    public readonly InputSlot<string> FilePath = new();
+
+    [Input(Guid = "1A2B3C4D-5E6F-7A8B-9C0D-1E2F3A4B5C6D")]
+    public readonly InputSlot<bool> FlipNormals = new(false);
+
+    [Output(Guid = "D4E5F6A7-8B9C-4D1E-2F3B-3C4D5E6F7A8B")]
+    public readonly Slot<int> MeshCount = new();
+
+    [Output(Guid = "77A21584-B35B-46B6-8056-1FEB4196C0B7")]
+    public readonly Slot<MeshBuffers> MeshData = new();
+
+    [Output(Guid = "A7B8C9D1-2E3F-4B4C-5D6E-6F7A8B9C1D2E")]
+    public readonly Slot<string> MeshNames = new();
+
+    [Output(Guid = "A1B2C3D4-5E6F-4A7B-8C9D-0E1F2A3B4C5D")]
+    public readonly Slot<string> Metadata = new();
+
+    [Input(Guid = "8B4C9D3E-6F0A-4B8C-9D1E-1F2B3C4D5E6F")]
+    public readonly InputSlot<bool> Normalize = new(true);
+
+    [Output(Guid = "9342C958-3D1F-40B0-B5E0-696812704812")]
+    public readonly Slot<BufferWithViews> Points = new();
+
+    [Input(Guid = "6AFF02C4-35C8-4875-BB25-D2B10ADFC276", MappedType = typeof(PostProcessPreset))]
+    public readonly InputSlot<int> PostProcessFlags = new((int)PostProcessPreset.Basic);
+
+    [Input(Guid = "7A3B8C2D-5E9F-4A7B-8C9D-0E1F2A3B4C5D")]
+    public readonly InputSlot<float> Scale = new(1.0f);
+
+    [Input(Guid = "2B3C4D5E-6F7A-8B9C-1D2E-3F4A5B6C7D8E")]
+    public readonly InputSlot<int> SelectedMeshIndex = new(-1);
+
+    [Output(Guid = "B2C3D4E5-6F7A-4B8C-9D1E-1F2B3C4D5E6F")]
+    public readonly Slot<int> VertexCount = new();
+
+    private int _cachedPostProcessFlags;
+    private Buffer _indexBuffer;
+    private Int3[] _indexBufferData = new Int3[0];
+    private Buffer _pointBuffer;
+    private Point[] _pointBufferData = new Point[0];
+    private Buffer _vertexBuffer;
+    private PbrVertex[] _vertexBufferData = new PbrVertex[0];
+
+    public AssimpImport()
+    {
+        MeshData.UpdateAction += Update;
+        _sceneResource = new Resource<Scene>(FilePath, TryLoadScene, false);
+        _sceneResource.AddDependentSlots(MeshData, Points);
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        var postProcessFlags = PostProcessFlags.GetValue(context);
+        var scale = Scale.GetValue(context);
+        var normalize = Normalize.GetValue(context);
+        var flipNormals = FlipNormals.GetValue(context);
+        var axisConversion = (AxisConversion)AxisConversionMode.GetValue(context);
+        var selectedMeshIndex = SelectedMeshIndex.GetValue(context);
+
+        // Check if post process flags changed and invalidate resource cache if needed
+        if (_cachedPostProcessFlags != postProcessFlags)
+        {
+            _cachedPostProcessFlags = postProcessFlags;
+            _sceneResource.MarkFileAsChanged();
+        }
+
+        if (!_sceneResource.TryGetValue(context, out var scene))
+        {
+            Log.Debug("No scene loaded", this);
+            MeshData.Value = null;
+            Points.Value = null;
+            return;
+        }
+
+        try
+        {
+            // Determine which meshes to load
+            var startMesh = 0;
+            var endMesh = scene.MeshCount;
+
+            if (selectedMeshIndex >= 0 && selectedMeshIndex < scene.MeshCount)
+            {
+                startMesh = selectedMeshIndex;
+                endMesh = selectedMeshIndex + 1;
+            }
+
+            // Count total vertices and faces
+            var totalVertices = 0;
+            var totalFaces = 0;
+            var meshNamesList = new StringBuilder();
+
+            for (var i = 0; i < scene.MeshCount; i++)
+            {
+                var mesh = scene.Meshes[i];
+                if (i >= startMesh && i < endMesh)
+                {
+                    totalVertices += mesh.VertexCount;
+                    totalFaces += mesh.FaceCount;
+                }
+
+                if (meshNamesList.Length > 0)
+                    meshNamesList.Append('|');
+                meshNamesList.Append(mesh.Name ?? $"Mesh{i}");
+            }
+
+            if (totalVertices == 0)
+            {
+                Log.Warning("Scene has no vertices", this);
+                MeshData.Value = null;
+                Points.Value = null;
+                OutputMetadata(0, 0, scene.MeshCount, Vector3.Zero, Vector3.Zero, meshNamesList.ToString());
+                return;
+            }
+
+            // Create vertex and index arrays
+            if (_vertexBufferData.Length != totalVertices)
+                _vertexBufferData = new PbrVertex[totalVertices];
+            if (_indexBufferData.Length != totalFaces)
+                _indexBufferData = new Int3[totalFaces];
+
+            // Fill arrays from selected meshes
+            var vertexOffset = 0;
+            var faceOffset = 0;
+
+            // Track bounding box for normalization
+            var minBounds = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            var maxBounds = new Vector3(float.MinValue, float.MinValue, float.MinValue);
+
+            for (var i = startMesh; i < endMesh; i++)
+            {
+                var mesh = scene.Meshes[i];
+
+                // Copy vertices
+                for (var v = 0; v < mesh.VertexCount; v++)
+                {
+                    var pos = mesh.Vertices[v];
+                    var normal = mesh.HasNormals ? mesh.Normals[v] : new Vector3(0, 1, 0);
+                    var uv = mesh.HasTextureCoords(0) ? mesh.TextureCoordinateChannels[0][v] : new Vector3(0, 0, 0);
+                    var color = mesh.HasVertexColors(0) ? mesh.VertexColorChannels[0][v] : new Vector4(1, 1, 1, 1);
+
+                    var position = new Vector3(pos.X, pos.Y, pos.Z);
+                    var normalVec = new Vector3(normal.X, normal.Y, normal.Z);
+
+                    // Apply axis conversion to position and normal
+                    ApplyAxisConversion(ref position, ref normalVec, axisConversion);
+
+                    // Apply flip normals
+                    if (flipNormals)
+                        normalVec = -normalVec;
+
+                    // Track bounds for normalization
+                    minBounds = Vector3.Min(minBounds, position);
+                    maxBounds = Vector3.Max(maxBounds, position);
+
+                    _vertexBufferData[vertexOffset + v] = new PbrVertex
+                                                              {
+                                                                  Position = position,
+                                                                  Normal = normalVec,
+                                                                  Tangent = Vector3.UnitX, // Will be calculated later if needed
+                                                                  Bitangent = Vector3.UnitY, // Will be calculated later if needed
+                                                                  Texcoord = new Vector2(uv.X, uv.Y),
+                                                                  Texcoord2 = Vector2.Zero,
+                                                                  Selection = color.X // Store first color channel in selection
+                                                              };
+                }
+
+                // Copy faces as indices
+                for (var f = 0; f < mesh.FaceCount; f++)
+                {
+                    var face = mesh.Faces[f];
+                    if (face.IndexCount == 3)
+                        _indexBufferData[faceOffset + f] = new Int3(
+                                                                    face.Indices[0] + vertexOffset,
+                                                                    face.Indices[1] + vertexOffset,
+                                                                    face.Indices[2] + vertexOffset
+                                                                   );
+                }
+
+                vertexOffset += mesh.VertexCount;
+                faceOffset += mesh.FaceCount;
+            }
+
+            // Calculate tangents from geometry and UVs
+            if (totalVertices > 0 && totalFaces > 0)
+                CalculateTangents(_vertexBufferData, _indexBufferData, totalFaces);
+
+            // Apply scaling and normalization
+            if (scale != 1.0f || normalize)
+            {
+                var boundsSize = maxBounds - minBounds;
+                var maxDimension = MathF.Max(boundsSize.X, MathF.Max(boundsSize.Y, boundsSize.Z));
+
+                // First normalize to unit cube if requested
+                var normalizeFactor = maxDimension > 0 && normalize ? 1.0f / maxDimension : 1.0f;
+                var finalScale = normalizeFactor * scale;
+
+                if (finalScale != 1.0f)
+                {
+                    // Calculate center offset for centering the model
+                    var center = (minBounds + maxBounds) * 0.5f;
+
+                    for (var i = 0; i < totalVertices; i++)
+                    {
+                        _vertexBufferData[i].Position = (_vertexBufferData[i].Position - center) * finalScale;
+                        // Renormalize normals after uniform scaling (they should remain unit vectors)
+                        _vertexBufferData[i].Normal = Vector3.Normalize(_vertexBufferData[i].Normal);
+                        // Tangents and bitangents also need renormalization
+                        _vertexBufferData[i].Tangent = Vector3.Normalize(_vertexBufferData[i].Tangent);
+                        _vertexBufferData[i].Bitangent = Vector3.Normalize(_vertexBufferData[i].Bitangent);
+                    }
+
+                    // Update bounds after transformation
+                    minBounds = (minBounds - center) * finalScale;
+                    maxBounds = (maxBounds - center) * finalScale;
+
+                    Log.Debug($"Applied scaling: normalize={normalize}, scale={scale}, final={finalScale}", this);
+                }
+            }
+
+            // Create GPU buffers
+            ResourceManager.SetupStructuredBuffer(_vertexBufferData, PbrVertex.Stride * totalVertices, PbrVertex.Stride, ref _vertexBuffer);
+            ResourceManager.CreateStructuredBufferSrv(_vertexBuffer, ref _vertexBufferWithViews.Srv);
+            ResourceManager.CreateStructuredBufferUav(_vertexBuffer, UnorderedAccessViewBufferFlags.None, ref _vertexBufferWithViews.Uav);
+            _vertexBufferWithViews.Buffer = _vertexBuffer;
+
+            const int stride = 3 * 4;
+            ResourceManager.SetupStructuredBuffer(_indexBufferData, stride * totalFaces, stride, ref _indexBuffer);
+            ResourceManager.CreateStructuredBufferSrv(_indexBuffer, ref _indexBufferWithViews.Srv);
+            ResourceManager.CreateStructuredBufferUav(_indexBuffer, UnorderedAccessViewBufferFlags.None, ref _indexBufferWithViews.Uav);
+            _indexBufferWithViews.Buffer = _indexBuffer;
+
+            _meshData.VertexBuffer = _vertexBufferWithViews;
+            _meshData.IndicesBuffer = _indexBufferWithViews;
+            MeshData.Value = _meshData;
+
+            OutputMetadata(totalVertices, totalFaces, endMesh - startMesh, minBounds, maxBounds, meshNamesList.ToString());
+            Log.Debug($"Loaded {totalVertices} vertices, {totalFaces} faces from {endMesh - startMesh} meshes", this);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to convert scene to mesh buffers: {ex.Message}", this);
+            MeshData.Value = null;
+        }
+
+        try
+        {
+            // Determine which meshes to load (same as mesh data)
+            var startMesh = 0;
+            var endMesh = scene.MeshCount;
+
+            if (selectedMeshIndex >= 0 && selectedMeshIndex < scene.MeshCount)
+            {
+                startMesh = selectedMeshIndex;
+                endMesh = selectedMeshIndex + 1;
+            }
+
+            // Count total vertices
+            var totalVertices = 0;
+            for (var i = startMesh; i < endMesh; i++)
+                totalVertices += scene.Meshes[i].VertexCount;
+
+            if (totalVertices == 0)
+            {
+                Points.Value = null;
+                return;
+            }
+
+            if (_pointBufferData.Length != totalVertices)
+                _pointBufferData = new Point[totalVertices];
+
+            var pointOffset = 0;
+
+            // Track bounds for scaling (same as mesh data)
+            var minBounds = new Vector3(float.MaxValue, float.MaxValue, float.MaxValue);
+            var maxBounds = new Vector3(float.MinValue, float.MinValue, float.MinValue);
+            for (var i = startMesh; i < endMesh; i++)
+            {
+                var mesh = scene.Meshes[i];
+                var hasNormals = mesh.HasNormals;
+                var hasColors = mesh.HasVertexColors(0);
+                var hasUVs = mesh.HasTextureCoords(0);
+
+                for (var v = 0; v < mesh.VertexCount; v++)
+                {
+                    var pos = mesh.Vertices[v];
+                    var normal = hasNormals ? mesh.Normals[v] : new Vector3(0, 1, 0);
+                    var color = hasColors ? mesh.VertexColorChannels[0][v] : new Vector4(1, 1, 1, 1);
+                    var uv = hasUVs ? mesh.TextureCoordinateChannels[0][v] : new Vector3(0, 0, 0);
+
+                    var position = new Vector3(pos.X, pos.Y, pos.Z);
+                    var normalVec = new Vector3(normal.X, normal.Y, normal.Z);
+
+                    // Apply axis conversion
+                    ApplyAxisConversion(ref position, ref normalVec, axisConversion);
+
+                    // Apply flip normals
+                    if (flipNormals)
+                        normalVec = -normalVec;
+
+                    // Track bounds
+                    minBounds = Vector3.Min(minBounds, position);
+                    maxBounds = Vector3.Max(maxBounds, position);
+
+                    _pointBufferData[pointOffset++] = new Point
+                                                          {
+                                                              Position = position,
+                                                              Orientation = Quaternion.Identity,
+                                                              Scale = Vector3.One,
+                                                              Color = new Vector4(color.X, color.Y, color.Z, color.W),
+                                                              F1 = 1.0f
+                                                          };
+                }
+            }
+
+            // Apply same scaling as mesh data
+            if (scale != 1.0f || normalize)
+            {
+                var boundsSize = maxBounds - minBounds;
+                var maxDimension = MathF.Max(boundsSize.X, MathF.Max(boundsSize.Y, boundsSize.Z));
+                var normalizeFactor = maxDimension > 0 && normalize ? 1.0f / maxDimension : 1.0f;
+                var finalScale = normalizeFactor * scale;
+
+                if (finalScale != 1.0f)
+                {
+                    var center = (minBounds + maxBounds) * 0.5f;
+                    for (var i = 0; i < totalVertices; i++)
+                        _pointBufferData[i].Position = (_pointBufferData[i].Position - center) * finalScale;
+                }
+            }
+
+            // Create GPU buffer for points
+            ResourceManager.SetupStructuredBuffer(_pointBufferData, Point.Stride * totalVertices, Point.Stride, ref _pointBuffer);
+            ResourceManager.CreateStructuredBufferSrv(_pointBuffer, ref _pointBufferWithViews.Srv);
+            ResourceManager.CreateStructuredBufferUav(_pointBuffer, UnorderedAccessViewBufferFlags.None, ref _pointBufferWithViews.Uav);
+            _pointBufferWithViews.Buffer = _pointBuffer;
+
+            Points.Value = _pointBufferWithViews;
+            Log.Debug($"Created {totalVertices} points from scene", this);
+        }
+        catch (Exception ex)
+        {
+            Log.Error($"Failed to convert scene to points: {ex.Message}", this);
+            Points.Value = null;
+        }
+    }
+
+    private bool TryLoadScene(FileResource file, Scene currentValue, out Scene newValue, out string failureReason)
+    {
+        var absolutePath = file.AbsolutePath;
+
+        try
+        {
+            using var importer = new AssimpContext();
+
+            // Use cached post process flags value
+            var postProcessSteps = GetPostProcessFlags(_cachedPostProcessFlags);
+
+            var scene = importer.ImportFile(absolutePath, postProcessSteps);
+
+            if (scene == null || scene.MeshCount == 0)
+            {
+                failureReason = $"Failed to load scene or no meshes found in {absolutePath}";
+                newValue = null;
+                return false;
+            }
+
+            failureReason = null;
+            newValue = scene;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            failureReason = $"Exception loading scene: {ex.Message}";
+            newValue = null;
+            return false;
+        }
+    }
+
+    private PostProcessSteps GetPostProcessFlags(int flagsValue)
+    {
+        var flags = (PostProcessPreset)flagsValue;
+
+        return flags switch
+                   {
+                       PostProcessPreset.None  => PostProcessSteps.None,
+                       PostProcessPreset.Basic => PostProcessSteps.Triangulate | PostProcessSteps.GenerateSmoothNormals,
+                       PostProcessPreset.Full => PostProcessSteps.Triangulate |
+                                                 PostProcessSteps.GenerateSmoothNormals |
+                                                 PostProcessSteps.GenerateUVCoords |
+                                                 PostProcessSteps.CalculateTangentSpace |
+                                                 PostProcessSteps.JoinIdenticalVertices |
+                                                 PostProcessSteps.RemoveRedundantMaterials |
+                                                 PostProcessSteps.ImproveCacheLocality,
+                       _ => PostProcessSteps.Triangulate | PostProcessSteps.GenerateSmoothNormals
+                   };
+    }
+
+    private void OutputMetadata(int vertexCount, int faceCount, int meshCount, Vector3 boundsMin, Vector3 boundsMax, string meshNames)
+    {
+        VertexCount.Value = vertexCount;
+        FaceCount.Value = faceCount;
+        MeshCount.Value = meshCount;
+        BoundsMin.Value = boundsMin;
+        BoundsMax.Value = boundsMax;
+        MeshNames.Value = meshNames;
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Vertices: {vertexCount:N0}");
+        sb.AppendLine($"Faces: {faceCount:N0}");
+        sb.AppendLine($"Meshes: {meshCount}");
+        sb.AppendLine($"Bounds Min: ({boundsMin.X:F2}, {boundsMin.Y:F2}, {boundsMin.Z:F2})");
+        sb.AppendLine($"Bounds Max: ({boundsMax.X:F2}, {boundsMax.Y:F2}, {boundsMax.Z:F2})");
+        if (meshCount > 1)
+            sb.AppendLine($"Mesh Names: {meshNames}");
+        Metadata.Value = sb.ToString();
+    }
+
+    private void ApplyAxisConversion(ref Vector3 position, ref Vector3 normal, AxisConversion conversion)
+    {
+        switch (conversion)
+        {
+            case AxisConversion.YUpToZUp:
+                // Convert Y-up to Z-up: swap Y and Z
+                (position.Y, position.Z) = (position.Z, position.Y);
+                (normal.Y, normal.Z) = (normal.Z, normal.Y);
+                break;
+            case AxisConversion.ZUpToYUp:
+                // Convert Z-up to Y-up: swap Y and Z
+                (position.Y, position.Z) = (position.Z, position.Y);
+                (normal.Y, normal.Z) = (normal.Z, normal.Y);
+                break;
+            case AxisConversion.FlipX:
+                position.X = -position.X;
+                normal.X = -normal.X;
+                break;
+            case AxisConversion.FlipY:
+                position.Y = -position.Y;
+                normal.Y = -normal.Y;
+                break;
+            case AxisConversion.FlipZ:
+                position.Z = -position.Z;
+                normal.Z = -normal.Z;
+                break;
+        }
+    }
+
+    private void CalculateTangents(PbrVertex[] vertices, Int3[] indices, int faceCount)
+    {
+        // Initialize tangents to zero
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            vertices[i].Tangent = Vector3.Zero;
+            vertices[i].Bitangent = Vector3.Zero;
+        }
+
+        // Calculate tangents for each face
+        for (var i = 0; i < faceCount; i++)
+        {
+            var i0 = indices[i].X;
+            var i1 = indices[i].Y;
+            var i2 = indices[i].Z;
+
+            var v0 = vertices[i0].Position;
+            var v1 = vertices[i1].Position;
+            var v2 = vertices[i2].Position;
+
+            var uv0 = vertices[i0].Texcoord;
+            var uv1 = vertices[i1].Texcoord;
+            var uv2 = vertices[i2].Texcoord;
+
+            var edge1 = v1 - v0;
+            var edge2 = v2 - v0;
+            var deltaUv1 = uv1 - uv0;
+            var deltaUv2 = uv2 - uv0;
+
+            // Handle degenerate UVs
+            var denominator = deltaUv1.X * deltaUv2.Y - deltaUv2.X * deltaUv1.Y;
+            if (MathF.Abs(denominator) < 1e-6f)
+                continue; // Skip faces with degenerate UV coordinates
+
+            var f = 1.0f / denominator;
+
+            var tangent = new Vector3(
+                                      f * (deltaUv2.Y * edge1.X - deltaUv1.Y * edge2.X),
+                                      f * (deltaUv2.Y * edge1.Y - deltaUv1.Y * edge2.Y),
+                                      f * (deltaUv2.Y * edge1.Z - deltaUv1.Y * edge2.Z)
+                                     );
+
+            var bitangent = new Vector3(
+                                        f * (-deltaUv2.X * edge1.X + deltaUv1.X * edge2.X),
+                                        f * (-deltaUv2.X * edge1.Y + deltaUv1.X * edge2.Y),
+                                        f * (-deltaUv2.X * edge1.Z + deltaUv1.X * edge2.Z)
+                                       );
+
+            vertices[i0].Tangent += tangent;
+            vertices[i1].Tangent += tangent;
+            vertices[i2].Tangent += tangent;
+
+            vertices[i0].Bitangent += bitangent;
+            vertices[i1].Bitangent += bitangent;
+            vertices[i2].Bitangent += bitangent;
+        }
+
+        // Orthogonalize tangents and normalize
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            var t = vertices[i].Tangent;
+            var n = vertices[i].Normal;
+            var b = vertices[i].Bitangent;
+
+            // Skip if no valid tangent was calculated
+            if (t.LengthSquared() < 0.0001f)
+            {
+                // Generate default tangent from normal
+                var absNx = MathF.Abs(n.X);
+                var absNy = MathF.Abs(n.Y);
+                var absNz = MathF.Abs(n.Z);
+
+                // Choose best axis for cross product
+                if (absNx <= absNy && absNx <= absNz)
+                    vertices[i].Tangent = Vector3.Normalize(Vector3.Cross(Vector3.UnitX, n));
+                else if (absNy <= absNx && absNy <= absNz)
+                    vertices[i].Tangent = Vector3.Normalize(Vector3.Cross(Vector3.UnitY, n));
+                else
+                    vertices[i].Tangent = Vector3.Normalize(Vector3.Cross(Vector3.UnitZ, n));
+
+                vertices[i].Bitangent = Vector3.Cross(n, vertices[i].Tangent);
+                continue;
+            }
+
+            // Gram-Schmidt orthogonalize
+            var tOrtho = t - n * Vector3.Dot(n, t);
+            if (tOrtho.LengthSquared() > 0.0001f)
+                tOrtho = Vector3.Normalize(tOrtho);
+
+            // Calculate handedness
+            var handedness = Vector3.Dot(Vector3.Cross(n, t), b) < 0.0f ? -1.0f : 1.0f;
+
+            vertices[i].Tangent = tOrtho;
+            vertices[i].Bitangent = Vector3.Normalize(b) * handedness;
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _pointBuffer?.Dispose();
+            _pointBufferWithViews?.Dispose();
+            _vertexBuffer?.Dispose();
+            _indexBuffer?.Dispose();
+            _vertexBufferWithViews?.Dispose();
+            _indexBufferWithViews?.Dispose();
+            _meshData?.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private enum PostProcessPreset
+    {
+        None,
+        Basic,
+        Full
+    }
+
+    private enum AxisConversion
+    {
+        None,
+        YUpToZUp,
+        ZUpToYUp,
+        FlipX,
+        FlipY,
+        FlipZ
+    }
+}

--- a/Operators/Lib/io/assimp/AssimpImport.t3
+++ b/Operators/Lib/io/assimp/AssimpImport.t3
@@ -1,0 +1,35 @@
+{
+  "Id": "e0b5b99d-c44f-434d-920d-422e88c75870"/*AssimpImport*/,
+  "Inputs": [
+    {
+      "Id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"/*FlipNormals*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "2b3c4d5e-6f7a-8b9c-1d2e-3f4a5b6c7d8e"/*SelectedMeshIndex*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "6aff02c4-35c8-4875-bb25-d2b10adfc276"/*PostProcessFlags*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "7a3b8c2d-5e9f-4a7b-8c9d-0e1f2a3b4c5d"/*Scale*/,
+      "DefaultValue": 0.0
+    },
+    {
+      "Id": "8b4c9d3e-6f0a-4b8c-9d1e-1f2b3c4d5e6f"/*Normalize*/,
+      "DefaultValue": false
+    },
+    {
+      "Id": "9c5d0e4f-7a1b-5c9d-2e3f-3b4c5d6e7f8a"/*AxisConversionMode*/,
+      "DefaultValue": 0
+    },
+    {
+      "Id": "b569d0cc-9f84-419c-a3db-91406df6a3f8"/*FilePath*/,
+      "DefaultValue": ""
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/io/assimp/AssimpImport.t3ui
+++ b/Operators/Lib/io/assimp/AssimpImport.t3ui
@@ -1,0 +1,170 @@
+{
+  "Id": "e0b5b99d-c44f-434d-920d-422e88c75870"/*AssimpImport*/,
+  "Description": "Import 3D models from 40+ formats including FBX, glTF, OBJ, Collada, STL, and more. Supports mesh data, point clouds, skeletal animations, and bone weights.",
+  "InputUis": [
+    {
+      "InputId": "b569d0cc-9f84-419c-a3db-91406df6a3f8"/*FilePath*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Description": "Path to the 3D model file to import. Supports 40+ formats including FBX, glTF, OBJ, Collada, STL, PLY, 3DS, and more.",
+      "Usage": "FilePath"
+    },
+    {
+      "InputId": "6aff02c4-35c8-4875-bb25-d2b10adfc276"/*PostProcessFlags*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 75.0
+      },
+      "Description": "Post-processing preset for the imported model. None: raw import; Basic: triangulation + smooth normals; Full: includes UV generation, tangent calculation, and optimization."
+    },
+    {
+      "InputId": "7a3b8c2d-5e9f-4a7b-8c9d-0e1f2a3b4c5d"/*Scale*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 150.0
+      },
+      "Description": "Uniform scale factor applied to the model after normalization."
+    },
+    {
+      "InputId": "8b4c9d3e-6f0a-4b8c-9d1e-1f2b3c4d5e6f"/*Normalize*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 225.0
+      },
+      "Description": "When enabled, normalizes the model to fit within a unit cube and centers it at the origin."
+    },
+    {
+      "InputId": "9c5d0e4f-7a1b-5c9d-2e3f-3b4c5d6e7f8a"/*AxisConversionMode*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 300.0
+      },
+      "Description": "Axis conversion for models from different coordinate systems. YUpToZUp converts Blender models, ZUpToYUp converts OpenGL/Unity models."
+    },
+    {
+      "InputId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"/*FlipNormals*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 375.0
+      },
+      "Description": "When enabled, flips the direction of all vertex normals. Useful for models with inverted winding order."
+    },
+    {
+      "InputId": "2b3c4d5e-6f7a-8b9c-1d2e-3f4a5b6c7d8e"/*SelectedMeshIndex*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 450.0
+      },
+      "Description": "Index of the specific mesh to import from multi-mesh files. Use -1 to import all meshes combined."
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "77a21584-b35b-46b6-8056-1feb4196c0b7"/*MeshData*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 200.0
+      },
+      "Description": "Imported mesh data with vertices, normals, tangents, and UVs."
+    },
+    {
+      "OutputId": "9342c958-3d1f-40b0-b5e0-696812704812"/*Points*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 300.0
+      },
+      "Description": "Point cloud representation of the mesh vertices."
+    },
+    {
+      "OutputId": "a1b2c3d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d"/*Metadata*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 400.0
+      },
+      "Description": "Formatted metadata string with vertex count, face count, and bounding box information."
+    },
+    {
+      "OutputId": "b2c3d4e5-6f7a-4b8c-9d1e-1f2b3c4d5e6f"/*VertexCount*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 500.0
+      },
+      "Description": "Total number of vertices in the imported mesh."
+    },
+    {
+      "OutputId": "c3d4e5f6-7a8b-4c9d-1e2f-2b3c4d5e6f7a"/*FaceCount*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 600.0
+      },
+      "Description": "Total number of triangular faces in the imported mesh."
+    },
+    {
+      "OutputId": "d4e5f6a7-8b9c-4d1e-2f3b-3c4d5e6f7a8b"/*MeshCount*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 700.0
+      },
+      "Description": "Number of meshes in the imported file."
+    },
+    {
+      "OutputId": "e5f6a7b8-9c1d-4e2f-3b4c-4d5e6f7a8b9c"/*BoundsMin*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 800.0
+      },
+      "Description": "Minimum bounding box corner of the imported mesh."
+    },
+    {
+      "OutputId": "f6a7b8c9-1d2e-4f3b-4c5d-5e6f7a8b9c1d"/*BoundsMax*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 900.0
+      },
+      "Description": "Maximum bounding box corner of the imported mesh."
+    },
+    {
+      "OutputId": "a7b8c9d1-2e3f-4b4c-5d6e-6f7a8b9c1d2e"/*MeshNames*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 1000.0
+      },
+      "Description": "Pipe-separated list of mesh names in the imported file."
+    },
+    {
+      "OutputId": "b1c2d3e4-5f6a-4b7c-8d9e-0f1a2b3c4d5e"/*SkeletonBuffers*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 1100.0
+      },
+      "Description": "GPU buffers containing bone data (bind poses, offset matrices) and vertex skin weights for skeletal animation."
+    },
+    {
+      "OutputId": "c2d3e4f5-6a7b-5c8d-9e1f-2b3c4d5e6f7a"/*BoneCount*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 1200.0
+      },
+      "Description": "Total number of bones in the skeleton hierarchy."
+    },
+    {
+      "OutputId": "d3e4f5a6-7b8c-6d9e-1f2b-4c5d6e7f8a9b"/*AnimationCount*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 1300.0
+      },
+      "Description": "Number of animation clips found in the imported model."
+    },
+    {
+      "OutputId": "e4f5a6b7-8c9d-7e9f-2c3d-5e6f7a8b9c1d"/*AnimationNames*/,
+      "Position": {
+        "X": 300.0,
+        "Y": 1400.0
+      },
+      "Description": "Pipe-separated list of animation clip names."
+    }
+  ]
+}


### PR DESCRIPTION
Operators for importing and exporting 3D model files using the Assimp library (via AssimpNetter).

## AssimpImport

The ultimate simple 3D model loader supporting 40+ file formats including OBJ, FBX, GLTF, GLB, STL, PLY, COLLADA, 3DS, BLEND, and more.

### Inputs

| Name                | Type   | Default | Description                             |
|---------------------|--------|---------|-----------------------------------------|
| `FilePath`          | string | ""      | Path to 3D model file                   |
| `PostProcessFlags`  | enum   | Basic   | Preprocessing preset: None, Basic, Full |
| `Scale`             | float  | 1.0     | Uniform scale multiplier                |
| `Normalize`         | bool   | true    | Normalize model to fit in unit cube     |
| `AxisConversion`    | enum   | None    | Axis conversion mode                    |
| `FlipNormals`       | bool   | false   | Flip all vertex normals                 |
| `SelectedMeshIndex` | int    | -1      | Load specific mesh (-1 for all)         |

### PostProcessFlags Options

- **None** - Raw mesh data, no processing
- **Basic** - Triangulate + generate smooth normals (default)
- **Full** - All optimizations: triangulation, smooth normals, UV generation, tangent space calculation, vertex joining, material cleanup, cache locality optimization

### AxisConversion Options

- **None** - No transformation
- **YUpToZUp** - Convert Y-up coordinate system to Z-up
- **ZUpToYUp** - Convert Z-up coordinate system to Y-up
- **FlipX** - Mirror across X axis
- **FlipY** - Mirror across Y axis
- **FlipZ** - Mirror across Z axis

### Outputs

| Name              | Type            | Description                                               |
|-------------------|-----------------|-----------------------------------------------------------|
| `MeshData`        | MeshBuffers     | GPU buffers for mesh rendering (vertices + indices)       |
| `Points`          | BufferWithViews | Points at each vertex position                            |
| `Metadata`        | string          | Human-readable info (vertices, faces, bounds, etc.)       |
| `VertexCount`     | int             | Total vertex count                                        |
| `FaceCount`       | int             | Total face/triangle count                                 |
| `MeshCount`       | int             | Number of meshes in file                                  |
| `BoundsMin`       | Vector3         | Bounding box minimum corner                               |
| `BoundsMax`       | Vector3         | Bounding box maximum corner                               |
| `MeshNames`       | string          | Pipe-delimited list of mesh names                         |
| `SkeletonBuffers` | SkeletonBuffers | Bone buffers, skin weight buffers, and animation metadata |
| `BoneCount`       | int             | Number of bones in skeleton                               |
| `AnimationCount`  | int             | Number of animation clips                                 |
| `AnimationNames`  | string          | Pipe-delimited list of animation names                    |

### Features

- **Multi-mesh support** - Load all meshes from a file or select a specific one by index
- **Automatic tangent calculation** - Computes proper tangent space for normal mapping with degenerate UV handling
- **Vertex color support** - Stores first color channel in Selection field
- **Metadata output** - Get statistics about loaded models
- **Resource caching** - Efficient file loading with automatic caching
- **Parameter change detection** - PostProcessFlags changes trigger automatic reload
- **Proper normalization** - Normals are renormalized after scaling/normalization
- **Animation support** - Extract bone hierarchy, skin weights, and animation clip metadata
- **Skeletal animation buffers** - GPU buffers for bones (bind/offset matrices) and vertex skin weights (up to 4 influences per vertex)

## AssimpExport

Export mesh or point cloud data to various 3D file formats with automatic counter-based naming.

### Inputs

| Name             | Type            | Default   | Description                                      |
|------------------|-----------------|-----------|--------------------------------------------------|
| `MeshData`       | MeshBuffers     | null      | GPU mesh buffers to export                       |
| `Points`         | BufferWithViews | null      | Points to export (alternative to mesh)           |
| `FolderPath`     | string          | "exports" | Output folder path (files auto-named)            |
| `ExportMesh`     | bool            | trigger   | Trigger button to export mesh data               |
| `ExportPoints`   | bool            | trigger   | Trigger button to export point data              |
| `ExportFormat`   | enum            | Auto      | Format preset (determines file extension)        |
| `MeshName`       | string          | "mesh"    | Base name for exported files                     |
| `ResetCounter`   | bool            | trigger   | Reset export counter to 1                        |
| `MaxVertexCount` | int             | 0         | Maximum vertices/points to export (0 = no limit) |
| `CustomFormat`   | string          | ""        | Custom format ID (when ExportFormat is Custom)   |
| `GltfOptions`    | enum            | Default   | glTF/GLB export options (reserved)               |

### ExportFormat Options

- **Auto** - Default to FBX format
- **Obj** - Wavefront OBJ (.obj)
- **Fbx** - Autodesk FBX (.fbx)
- **Gltf** - glTF 2.0 JSON (.gltf)
- **Glb** - glTF 2.0 Binary (.glb)
- **Stl** - STL for 3D printing (.stl)
- **Ply** - Stanford PLY (.ply)
- **Collada** - COLLADA (.dae)
- **ThreeDs** - 3D Studio (.3ds)
- **Custom** - Use custom format ID

### Outputs

| Name            | Type   | Description                              |
|-----------------|--------|------------------------------------------|
| `Success`       | bool   | True if export succeeded                 |
| `StatusMessage` | string | Export result: filename or error message |

### Features

- **Automatic counter-based naming** - Files are named `MeshName_001.ext`, `MeshName_002.ext`, etc.
- **Folder-based output** - Specify a folder; filenames are generated automatically
- **Dual export triggers** - Separate buttons for mesh and point cloud export
- **Counter reset** - Reset the counter to start a new export sequence
- **Vertex/Point limiter** - Set `MaxVertexCount` > 0 to limit exported vertices/points (0 = no limit)
- **Wide format support** - Export to 20+ formats (FBX, glTF, OBJ, STL, PLY, COLLADA, 3DS, etc.)
- **Complete data export** - Includes tangents, bitangents, and vertex colors when present
- **Automatic directory creation** - Creates output directories if they don't exist
- **Filename sanitization** - Invalid characters in MeshName are automatically replaced with underscores

### Usage Examples

#### Basic mesh export

```
CubeMesh → AssimpExport (FolderPath: "exports", MeshName: "cube", ExportFormat: Fbx, ExportMesh: trigger)
→ Creates: exports/cube_001.fbx, cube_002.fbx, etc.
```

#### Export to glTF

```
Model → AssimpExport (FolderPath: "C:/Models/glTF", MeshName: "character", ExportFormat: Glb, ExportMesh: trigger)
→ Creates: C:/Models/glTF/character_001.glb
```

#### Export point cloud

```
PointCloud → AssimpExport (FolderPath: "pointclouds", ExportFormat: Ply, ExportPoints: trigger)
→ Creates: pointclouds/mesh_001.ply
```

#### Reset counter and start new sequence

```
Counter → IntDisplay
AssimpExport (ResetCounter: trigger) → Counter resets to 1
```

#### Export loop (exporting frames)

```
Time (0..1) → AssimpExport (ExportMesh: triggered each time)
→ Creates: mesh_001.fbx, mesh_002.fbx, ..., mesh_999.fbx
```

## Technical Notes

- Uses AssimpNetter v6.0.2.1 (Assimp 6.x)
- Import uses Resource<T> caching pattern for efficient file loading
- Export reads back GPU buffers using staging resources
- Proper disposal of GPU resources implemented
- Tangent space calculation uses the Lengyel algorithm with degenerate UV protection
- Automatic triangulation of quads and n-gons
- Smoothing groups converted to vertex normals
- PostProcessFlags changes trigger automatic reload via cache invalidation
- Normals are renormalized after scaling/normalization to maintain unit length
- Export includes tangents, bitangents, and vertex colors when available
- Output directories are created automatically if needed
- Filename sanitization removes invalid characters (<>:"/\\|?*) and limits length to 100 characters

## Supported Formats

### Import Formats (40+)

3DS, 3D, AC, AC3D, ACC, AMJ, ASE, ASK, B3D, BLEND, BVH, COB, DXF, ENFF, FBX, GLTF, GLB, IRR, IRRMESH, LWO, LWS, LXO, MD2, MD3, MD5, MDC, MDL, NFF, NDO, OBJ, OFF, OGEX, PLY, MS3D, LWO, RRM, Q3D, Q3BSP, RAW, SIB, SMD, STP, STL, TERRAGEN, 3D, X, X3D, XGL, ZGL

### Export Formats (20+)

3DS, ASE, ASSBIN, ASSXML, BVH, COLLADA, DXF, FBX, GLB, GLTF, M3D, OBJ, PLY, PMD, PMX, STEP, STL, TER, X, X3D, XGL