### PR TITLE
fix: changes in keyframes don't reflect in [EaseKeys] when playback is paused

### DIFF
--- a/Operators/Lib/numbers/float/process/EaseKeys.cs
+++ b/Operators/Lib/numbers/float/process/EaseKeys.cs
@@ -17,9 +17,11 @@ internal sealed class EaseKeys : Instance<EaseKeys>
 
     private void Update(EvaluationContext context)
     {
+        var inputValue = Value.GetValue(context);
+
         if (!TryFindCurveWithIndex(out var curve))
         {
-            Result.Value = Value.GetValue(context);
+            Result.Value = inputValue;
             return;
         }
 
@@ -45,7 +47,7 @@ internal sealed class EaseKeys : Instance<EaseKeys>
         }
         else
         {
-            Result.Value = Value.GetValue(context);
+            Result.Value = inputValue;
             return;
         }
 

--- a/Operators/Lib/numbers/vec2/process/EaseVec2Keys.cs
+++ b/Operators/Lib/numbers/vec2/process/EaseVec2Keys.cs
@@ -17,9 +17,11 @@ internal sealed class EaseVec2Keys : Instance<EaseVec2Keys>
 
     private void Update(EvaluationContext context)
     {
+        var inputValue = Value.GetValue(context);
+
         if (!TryFindCurves(out var curves))
         {
-            Result.Value = Value.GetValue(context);
+            Result.Value = inputValue;
             return;
         }
 
@@ -46,7 +48,7 @@ internal sealed class EaseVec2Keys : Instance<EaseVec2Keys>
             }
             else
             {
-                Result.Value[i] = Value.GetValue(context)[i];
+                Result.Value[i] = inputValue[i];
                 continue;
             }
 

--- a/Operators/Lib/numbers/vec3/process/EaseVec3Keys.cs
+++ b/Operators/Lib/numbers/vec3/process/EaseVec3Keys.cs
@@ -17,9 +17,11 @@ internal sealed class EaseVec3Keys : Instance<EaseVec3Keys>
 
     private void Update(EvaluationContext context)
     {
+        var inputValue = Value.GetValue(context);
+
         if (!TryFindCurves(out var curves))
         {
-            Result.Value = Value.GetValue(context);
+            Result.Value = inputValue;
             return;
         }
 
@@ -46,7 +48,7 @@ internal sealed class EaseVec3Keys : Instance<EaseVec3Keys>
             }
             else
             {
-                Result.Value[i] = Value.GetValue(context)[i];
+                Result.Value[i] = inputValue[i];
                 continue;
             }
 


### PR DESCRIPTION
removes artificial limitation imposed by [Damp]-style operators, where the animation would be messed up if the operator processed during paused playback. since [EaseKeys] operators rely on keyframe data, they are fully deterministic and don't have this issue.