### PR TITLE
Fix - SearchAndReplace for .fnt

### DIFF
--- a/Operators/Lib/render/basic/Text.t3
+++ b/Operators/Lib/render/basic/Text.t3
@@ -194,7 +194,7 @@
         {
           "Id": "4fe3f641-1c36-4970-be71-dafb5632fb53"/*SearchPattern*/,
           "Type": "System.String",
-          "Value": "\\.fnt"
+          "Value": ".fnt"
         },
         {
           "Id": "de8297ae-c7d8-414a-8825-d0ff9c2e3d78"/*Replace*/,

--- a/Operators/Lib/render/basic/TextOutlines2.t3
+++ b/Operators/Lib/render/basic/TextOutlines2.t3
@@ -190,7 +190,7 @@
         {
           "Id": "4fe3f641-1c36-4970-be71-dafb5632fb53"/*SearchPattern*/,
           "Type": "System.String",
-          "Value": "\\.fnt"
+          "Value": ".fnt"
         },
         {
           "Id": "de8297ae-c7d8-414a-8825-d0ff9c2e3d78"/*Replace*/,


### PR DESCRIPTION
Fixed [SearchAndReplace] in [Text] and [TextOutlines2]. changed "\\*.fnt" to "*.fnt"