### PR TITLE
Fix: update to align with Roslyn compiler changes in VS2026

### DIFF
--- a/Editor/Gui/Graph/Legacy/Interaction/Connections/ConnectionMaker.cs
+++ b/Editor/Gui/Graph/Legacy/Interaction/Connections/ConnectionMaker.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using T3.Core.Operator;
@@ -530,7 +530,8 @@ internal static class ConnectionMaker
                                                             && c.ConnectionType == firstConnectionType);
             if (validForMultiInput)
             {
-                var oldConnections = connectionList.ToArray().Reverse();
+                var oldConnections = connectionList.ToArray();
+                Array.Reverse(oldConnections);
                 connectionList.Clear();
                 foreach (var c in oldConnections)
                 {

--- a/Editor/UiModel/Modification/Combine.cs
+++ b/Editor/UiModel/Modification/Combine.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using T3.Core.Model;
 using T3.Core.Operator;
 using T3.Core.SystemUi;
@@ -224,8 +224,9 @@ internal static class Combine
 
         var newSymbolChildId = addCommand.AddedChildId;
 
-        foreach (var con in inputConnections.Reverse()) // reverse for multi input order preservation
+        for (var i = inputConnections.Length - 1; i >= 0; i--) // reverse for multi input order preservation
         {
+            var con = inputConnections[i];
             var sourceId = con.SourceParentOrChildId;
             var sourceSlotId = con.SourceSlotId;
             var targetId = newSymbolChildId;
@@ -235,8 +236,9 @@ internal static class Combine
             parentCompositionSymbol.AddConnection(newConnection);
         }
 
-        foreach (var con in outputConnections.Reverse()) // reverse for multi input order preservation
+        for (var i = outputConnections.Length - 1; i >= 0; i--) // reverse for multi input order preservation
         {
+            var con = outputConnections[i];
             var sourceId = newSymbolChildId;
             var sourceSlotId = connectionToNewSlotIdMap[con];
             var targetId = con.TargetParentOrChildId;


### PR DESCRIPTION
Goal: Proper compilation using VS2026

- Refactor list reversal to avoid LINQ Reverse()
- Updated list reversal logic in ConnectionMaker.cs and Combine.cs to use Array.Reverse and manual for-loops instead of LINQ's .Reverse(). 
- No more dealing with void return type of Reverse, compiles with old/new roslyn versions. 

No functional changes made. 

