### PR TITLE
Fix: [Point] initialization with AddSeparator enabled

### DIFF
--- a/Operators/TypeOperators/Values/Point.cs
+++ b/Operators/TypeOperators/Values/Point.cs
@@ -46,6 +46,10 @@ public sealed class Point : Instance<Point>, ITransformable
         var pos = Position.GetValue(context);
         _addSeparator = AddSeparator.GetValue(context);
 
+        // If separator state changed, we need to rebuild the buffer
+        var separatorChanged = _addSeparator != _lastAddSeparator;
+        _lastAddSeparator = _addSeparator;
+
         var rot = Quaternion.CreateFromAxisAngle(System.Numerics.Vector3.Normalize( RotationAxis.GetValue(context)), RotationAngle.GetValue(context) * MathUtils.ToRad);
         var array = _addSeparator ? _pointListWithSeparator : _pointList;
         OutPosition.Value = pos;
@@ -56,7 +60,14 @@ public sealed class Point : Instance<Point>, ITransformable
         array.TypedElements[0].F2 = F2.GetValue(context);
         array.TypedElements[0].Orientation = rot;
         ResultList.Value = array;
-            
+
+        // Force buffer update if separator state changed or on first run
+        if (separatorChanged || !_isBufferInitialized)
+        {
+            UpdateBuffer();
+            _isBufferInitialized = true;
+        }
+
         ResultList.DirtyFlag.Clear();
         OutPosition.DirtyFlag.Clear();
     }
@@ -97,7 +108,9 @@ public sealed class Point : Instance<Point>, ITransformable
     private Buffer? _buffer;
     private readonly BufferWithViews _bufferWithViews = new() ;
     private bool _addSeparator;
-        
+    private bool _lastAddSeparator;
+    private bool _isBufferInitialized = false;
+
     [Input(Guid = "a0a453db-d8f1-415a-9a98-3c88a25b15e7")]
     public readonly InputSlot<System.Numerics.Vector3> Position = new();
 


### PR DESCRIPTION
### Problem
When the Point operator had the AddSeparator input enabled in the graph, the buffer was being initialized with the wrong size (1 element) on start. The constructor called UpdateBuffer() before the AddSeparator value could be evaluated, resulting in a buffer sized for a single point instead of the required 2-element list (point + separator).

This caused the CombineBuffers operator to receive incorrectly sized buffers from Points with separators, leading to missing or corrupted data.
As shown here: 

https://github.com/user-attachments/assets/ef7764fe-a4b5-4de8-9b51-7f8c2175e8ec

