### PR TITLE
Fix right-mouse-click add operator/annotation placement

### DIFF
--- a/Editor/Gui/MagGraph/Interaction/GraphContextMenu.cs
+++ b/Editor/Gui/MagGraph/Interaction/GraphContextMenu.cs
@@ -318,14 +318,14 @@ internal static class GraphContextMenu
         if (CustomComponents.DrawMenuItem((int)MenuItemIds.AddNode, Icon.None, "Operator",
                                           "TAB", reserveIconColumn: false, state: muted))
         {
-            var posOnCanvas = context.View.InverseTransformPositionFloat(ImGui.GetMousePos());
+            var posOnCanvas = context.View.InverseTransformPositionFloat(CustomComponents.ScreenPosOnOpeningContextMenu);
             context.Placeholder.OpenOnCanvas(context, posOnCanvas);
         }
 
         if (CustomComponents.DrawMenuItem((int)MenuItemIds.AddAnnotation, Icon.None, "Annotation",
                                           UserActions.AddAnnotation.ListShortcuts(), reserveIconColumn: false, state: muted))
         {
-            var newAnnotation = NodeActions.AddAnnotation(nodeSelection, context.View, context.CompositionInstance);
+            var newAnnotation = NodeActions.AddAnnotation(nodeSelection, context.View, context.CompositionInstance, CustomComponents.ScreenPosOnOpeningContextMenu);
             context.ActiveAnnotationId = newAnnotation.Id;
             context.StateMachine.SetState(GraphStates.RenameAnnotation, context);
         }

--- a/Editor/Gui/Styling/CustomComponents.Menus.cs
+++ b/Editor/Gui/Styling/CustomComponents.Menus.cs
@@ -1,4 +1,4 @@
-﻿using ImGuiNET;
+using ImGuiNET;
 using T3.Core.DataTypes.Vector;
 using T3.Core.Utils;
 using T3.Editor.Gui.Input;
@@ -9,6 +9,9 @@ namespace T3.Editor.Gui.Styling;
 internal static partial class CustomComponents
 {
     private static Action _cachedDrawMenuItems;
+
+    /// <summary>Screen position of the right-click that opened the most recent scroll-canvas context menu.</summary>
+    internal static Vector2 ScreenPosOnOpeningContextMenu { get; private set; }
 
     public static void ContextMenuForItem(Action drawMenuItems, string title = null, string id = "context_menu",
                                           ImGuiPopupFlags flags = ImGuiPopupFlags.MouseButtonRight)
@@ -255,7 +258,7 @@ internal static partial class CustomComponents
 
         if (ImGui.BeginPopupContextWindow("windows_context_menu"))
         {
-            ImGui.GetMousePosOnOpeningCurrentPopup();
+            ScreenPosOnOpeningContextMenu = ImGui.GetMousePosOnOpeningCurrentPopup();
             contextMenuIsOpen = true;
 
             // Assign to static field to avoid closure allocations

--- a/Editor/UiModel/Modification/NodeActions.cs
+++ b/Editor/UiModel/Modification/NodeActions.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -104,10 +104,11 @@ internal static class NodeActions
         nodeSelection.Clear();
     }
 
-    public static Annotation AddAnnotation(NodeSelection nodeSelection, ScalableCanvas canvas, Instance compositionOp)
+    /// <param name="placementScreenPos">Screen position to place the annotation at when nothing is selected.</param>
+    public static Annotation AddAnnotation(NodeSelection nodeSelection, ScalableCanvas canvas, Instance compositionOp, Vector2? placementScreenPos = null)
     {
         var size = new Vector2(100, 140);
-        var posOnCanvas = canvas.InverseTransformPositionFloat(ImGui.GetMousePos());
+        var posOnCanvas = canvas.InverseTransformPositionFloat(placementScreenPos ?? ImGui.GetMousePos());
         var area = new ImRect(posOnCanvas, posOnCanvas + size);
 
         if (nodeSelection.IsAnythingSelected())


### PR DESCRIPTION
Capture position when right-clicking / opening context menu and use it upon creation of operator and/or annotation. Keyboard shortcuts (TAB + Shift+A) stay as they are, using the current active mouse pointer location.