### PR TITLE
Audio mutes at negative offset 

### DIFF
--- a/Core/Audio/SoundtrackClipStream.cs
+++ b/Core/Audio/SoundtrackClipStream.cs
@@ -212,7 +212,7 @@ internal sealed class SoundtrackClipStream
         var isOutOfBounds = elapsedInClipSecs < 0
                             || targetSourcePosSecs < 0
                             || targetSourcePosSecs >= sourceEndSecs
-                            || (hasClipEnd && TargetTime >= clipEndSecs);
+                            //|| (hasClipEnd && TargetTime >= clipEndSecs);
         
         // Check if paused in mixer
         var flags = BassMix.ChannelFlags(StreamHandle, 0, 0);

--- a/Core/Audio/SoundtrackClipStream.cs
+++ b/Core/Audio/SoundtrackClipStream.cs
@@ -211,7 +211,7 @@ internal sealed class SoundtrackClipStream
         // muted until the playhead reaches valid source time instead of starting the audio early.
         var isOutOfBounds = elapsedInClipSecs < 0
                             || targetSourcePosSecs < 0
-                            || targetSourcePosSecs >= sourceEndSecs
+                            || targetSourcePosSecs >= sourceEndSecs;
                             //|| (hasClipEnd && TargetTime >= clipEndSecs);
         
         // Check if paused in mixer


### PR DESCRIPTION
Negative offset in the Project Sound Track  resulted in the playback being muted after 0 on the timeline
https://github.com/tixl3d/tixl/issues/1137

This seems to fix it.
