### PR TITLE
feat: add per-point Space mode to SoftTransformPoints

### DIFF
--- a/Operators/Lib/Assets/shaders/points/modify/SoftTransformPoints.hlsl
+++ b/Operators/Lib/Assets/shaders/points/modify/SoftTransformPoints.hlsl
@@ -31,6 +31,7 @@ cbuffer Params : register(b1)
     // float UseWAsWeight;
     int VolumeShape; // 28
     int StrengthFactor;
+    int CoordinateSpace; // 0 = Object, 1 = Point
 }
 
 StructuredBuffer<Point> SourcePoints : register(t0);
@@ -98,25 +99,49 @@ static const float VolumeZebra = 3.5;
     float strength = s * Strength * (StrengthFactor == 0 ? 1 : (StrengthFactor == 1) ? p.FX1
                                                                                      : p.FX2);
 
-    float3 volumeCenter = TransformVolume._m30_m31_m32_m03.xyz;
-    float3 posInVolume2 = posInObject + volumeCenter.xyz;
-
-    float3 rot = RotateAxis * PI / 180 * strength;
-
-    float4 rotationX = qFromAngleAxis(rot.x, float3(1, 0, 0));
-    float4 rotationY = qFromAngleAxis(rot.y, float3(0, 1, 0));
-    float4 rotationZ = qFromAngleAxis(rot.z, float3(0, 0, 1));
-
-    posInVolume2 = qRotateVec3(posInVolume2, rotationX);
-    posInVolume2 = qRotateVec3(posInVolume2, rotationY);
-    posInVolume2 = qRotateVec3(posInVolume2, rotationZ);
-
-    p.Position = lerp(p.Position, -volumeCenter.xyz + posInVolume2 * Scale * ScaleMagnitude, strength) + strength * Translate;
-    p.Rotation = qMul(p.Rotation, rotationX);
-
     float fx1 = SourcePoints[i.x].FX1;
-    p.FX1 = lerp(fx1, fx1 * ScaleFx1 + OffsetFx1, strength);
 
-    p.Position.y += Translate.y * strength;
+    if (CoordinateSpace == 0) // Object space: pivot is the set origin
+    {
+        float3 volumeCenter = TransformVolume._m30_m31_m32_m03.xyz;
+        float3 posInVolume2 = posInObject + volumeCenter.xyz;
+
+        float3 rot = RotateAxis * PI / 180 * strength;
+
+        float4 rotationX = qFromAngleAxis(rot.x, float3(1, 0, 0));
+        float4 rotationY = qFromAngleAxis(rot.y, float3(0, 1, 0));
+        float4 rotationZ = qFromAngleAxis(rot.z, float3(0, 0, 1));
+
+        posInVolume2 = qRotateVec3(posInVolume2, rotationX);
+        posInVolume2 = qRotateVec3(posInVolume2, rotationY);
+        posInVolume2 = qRotateVec3(posInVolume2, rotationZ);
+
+        p.Position = lerp(p.Position, -volumeCenter.xyz + posInVolume2 * Scale * ScaleMagnitude, strength) + strength * Translate;
+        p.Rotation = qMul(p.Rotation, rotationX);
+        p.FX1 = lerp(fx1, fx1 * ScaleFx1 + OffsetFx1, strength);
+    }
+    else // Point space: each point transforms around its own center
+    {
+        float4 origRotation = p.Rotation;
+
+        float3 rot = RotateAxis * PI / 180 * strength;
+
+        float4 rotationX = qFromAngleAxis(rot.x, float3(1, 0, 0));
+        float4 rotationY = qFromAngleAxis(rot.y, float3(0, 1, 0));
+        float4 rotationZ = qFromAngleAxis(rot.z, float3(0, 0, 1));
+
+        float4 rotFull = qMul(rotationX, qMul(rotationY, rotationZ));
+
+        // Spin the point's own orientation about its center, position stays put
+        p.Rotation = qMul(origRotation, rotFull);
+
+        // Displace the point in its own local frame
+        p.Position += qRotateVec3(Translate, origRotation) * strength;
+
+        // Scale each point individually about its own center
+        p.Scale *= lerp(1, Scale * ScaleMagnitude, strength);
+        p.FX1 = lerp(fx1, fx1 * ScaleFx1 + OffsetFx1, strength);
+    }
+
     ResultPoints[i.x] = p;
 }

--- a/Operators/Lib/Symbols/point/transform/SoftTransformPoints.cs
+++ b/Operators/Lib/Symbols/point/transform/SoftTransformPoints.cs
@@ -74,7 +74,16 @@ internal sealed class SoftTransformPoints : Instance<SoftTransformPoints>, ITran
     [Input(Guid = "a7960bff-b388-4ebe-828d-4aedccf62d72", MappedType = typeof(FModes))]
     public readonly InputSlot<int> StrengthFactor = new InputSlot<int>();
 
+    [Input(Guid = "ee8619ad-7cd8-4f9e-bdd6-a924a3c4bee2", MappedType = typeof(Spaces))]
+    public readonly InputSlot<int> Space = new InputSlot<int>();
+
         
+    private enum Spaces
+    {
+        Object,
+        Point,
+    }
+
     private enum Shapes
     {
         Sphere,

--- a/Operators/Lib/Symbols/point/transform/SoftTransformPoints.t3
+++ b/Operators/Lib/Symbols/point/transform/SoftTransformPoints.t3
@@ -94,6 +94,10 @@
       }
     },
     {
+      "Id": "ee8619ad-7cd8-4f9e-bdd6-a924a3c4bee2"/*Space*/,
+      "DefaultValue": 0
+    },
+    {
       "Id": "f9025937-8e74-4f2d-b8f1-90e56e601137"/*Visibility*/,
       "DefaultValue": "Inherit"
     },
@@ -1414,6 +1418,12 @@
       "SourceSlotId": "431b39fd-4b62-478b-bbfa-4346102c3f61",
       "TargetParentOrChildId": "f98419a9-4ca5-4d89-abe4-cad24797d332",
       "TargetSlotId": "16f98211-fe97-4235-b33a-ddbbd2b5997f"
+    },
+    {
+      "SourceParentOrChildId": "00000000-0000-0000-0000-000000000000",
+      "SourceSlotId": "ee8619ad-7cd8-4f9e-bdd6-a924a3c4bee2",
+      "TargetParentOrChildId": "b483a920-948b-4f26-ab06-45c41aae7117",
+      "TargetSlotId": "49556d12-4cd1-4341-b9d8-c356668d296c"
     }
   ]
 }

--- a/Operators/Lib/Symbols/point/transform/SoftTransformPoints.t3ui
+++ b/Operators/Lib/Symbols/point/transform/SoftTransformPoints.t3ui
@@ -145,6 +145,13 @@
       "Format": "{0:0.0}°"
     },
     {
+      "InputId": "ee8619ad-7cd8-4f9e-bdd6-a924a3c4bee2"/*Space*/,
+      "Position": {
+        "X": -876.99396,
+        "Y": 1971.9124
+      }
+    },
+    {
       "InputId": "f9025937-8e74-4f2d-b8f1-90e56e601137"/*Visibility*/,
       "Position": {
         "X": 2011.0109,


### PR DESCRIPTION
Adds a `Space` input to `SoftTransformPoints` that switches the transform between
`Object` and `Point` space, letting each point change around its own center
(position, rotation, scale) instead of a shared volume pivot.

Default behavior remains unchanged by sticking to the OBJECT setting. 


DEMO 



https://github.com/user-attachments/assets/c6c2a13f-ad72-4d4a-a44f-2a995e55a13b



- `.cs`: new `Space` input (enum `Spaces { Object, Point }`, default `Object`)
- `.t3`: input registration + wiring to the shader's `CoordinateSpace` parameter
- `.t3ui`: UI toggle for the new input
- `.hlsl`:
  - Object space (unchanged behavior): transforms around the volume
  - Point space: each point spins its own orientation (`p.Rotation = qMul(origRotation, rotFull)`), is displaced in its own local frame (`p.Position += qRotateVec3(Translate, origRotation) * strength`), and scales individually (`p.Scale *= lerp(1, Scale * ScaleMagnitude, strength)`)


