### PR TITLE
core: skip dot-folders when scanning package symbols, UIs and source code

### DIFF
--- a/Core/Model/SymbolPackage.cs
+++ b/Core/Model/SymbolPackage.cs
@@ -56,7 +56,22 @@ public abstract partial class SymbolPackage : IResourcePackage
             if (!Directory.Exists(dir))
                 return [];
             
-            return Directory.EnumerateFiles(dir, $"*{SymbolExtension}", SearchOption.AllDirectories);
+            return EnumerateSymbolFilesRecursively(new DirectoryInfo(dir));
+        }
+    }
+
+    private static IEnumerable<string> EnumerateSymbolFilesRecursively(DirectoryInfo directory)
+    {
+        foreach (var file in directory.EnumerateFiles($"*{SymbolExtension}"))
+            yield return file.FullName;
+
+        foreach (var subDirectory in directory.EnumerateDirectories())
+        {
+            if (subDirectory.Name.StartsWith('.'))
+                continue;
+
+            foreach (var file in EnumerateSymbolFilesRecursively(subDirectory))
+                yield return file;
         }
     }
 

--- a/Editor/UiModel/EditableSymbolProject.cs
+++ b/Editor/UiModel/EditableSymbolProject.cs
@@ -170,8 +170,22 @@ internal sealed partial class EditableSymbolProject : EditorSymbolPackage
         if (!symbolsDirectory.Exists)
             return [];
 
-        return symbolsDirectory.EnumerateFiles($"*{fileExtension}", SearchOption.AllDirectories)
-                               .Select(x => x.FullName);
+        return EnumerateOperatorFiles(symbolsDirectory);
+
+        IEnumerable<string> EnumerateOperatorFiles(DirectoryInfo directory)
+        {
+            foreach (var file in directory.EnumerateFiles($"*{fileExtension}"))
+                yield return file.FullName;
+
+            foreach (var subDirectory in directory.EnumerateDirectories())
+            {
+                if (subDirectory.Name.StartsWith('.'))
+                    continue;
+
+                foreach (var nestedFile in EnumerateOperatorFiles(subDirectory))
+                    yield return nestedFile;
+            }
+        }
     }
 
     protected override void InitializeAssets()

--- a/Editor/UiModel/EditorSymbolPackage.cs
+++ b/Editor/UiModel/EditorSymbolPackage.cs
@@ -408,7 +408,7 @@ internal class EditorSymbolPackage : SymbolPackage
                 return [];
             }
             
-            return Directory.EnumerateFiles(dir, $"*{SymbolUiExtension}", SearchOption.AllDirectories);
+            return EnumeratePackageFiles(new DirectoryInfo(dir), $"*{SymbolUiExtension}");
         }
     }
 
@@ -423,7 +423,22 @@ internal class EditorSymbolPackage : SymbolPackage
                 return [];
             }
             
-            return Directory.EnumerateFiles(dir, $"*{SourceCodeExtension}", SearchOption.AllDirectories);
+            return EnumeratePackageFiles(new DirectoryInfo(dir), $"*{SourceCodeExtension}");
+        }
+    }
+
+    private static IEnumerable<string> EnumeratePackageFiles(DirectoryInfo directory, string pattern)
+    {
+        foreach (var file in directory.EnumerateFiles(pattern))
+            yield return file.FullName;
+
+        foreach (var subDirectory in directory.EnumerateDirectories())
+        {
+            if (subDirectory.Name.StartsWith('.'))
+                continue;
+
+            foreach (var file in EnumeratePackageFiles(subDirectory, pattern))
+                yield return file;
         }
     }
 


### PR DESCRIPTION
Files in .temp were being referenced and conflicting with files in release builds. (this may only effect people developing or using dev/alpha builds) . It bit me while working on my other PRs , leading to new files not being properly updated on rebuilds.

This may or may not be needed with recent move of .temp. 
 
The per-project build output now lives in `.temp/` inside each package folder.
The recursive `EnumerateFiles` scans used for symbols, UIs and source code picked
up those artifacts as real package content (duplicates / stale copies).

Replaces `SearchOption.AllDirectories` with a recursive walker that skips any
sub-directory whose name starts with `.` — the same convention the engine already
uses (`TixlAssemblyLoadContext`). Covers `.temp`, `.git`, and any future dot-folder
automatically.

Applied at 3 sites:
- `Core/Model/SymbolPackage.cs` — symbol search
- `Editor/UiModel/EditorSymbolPackage.cs` — symbol-UI and source-code search
- `Editor/UiModel/EditableSymbolProject.cs` — operator file find

Notes / possible follow-ups:
- The three identical walkers could be extracted into a shared `FileUtils` helper.
- Chose a `.`-prefix rule over matching `FileLocations.TempSubfolder` by name so
  other dot-folders are covered without upkeep.
