### PR TITLE
feat: new operators RepeatShapePoints and ClosedLoopMesh shape repeater operators

### DIFF
--- a/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.cs
+++ b/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.cs
@@ -110,15 +110,16 @@ internal sealed class ClosedLoopMesh : Instance<ClosedLoopMesh>
                     Vector3 Pc = positions[tri.Z];
 
                     var faceNormal = Vector3.Normalize(Vector3.Cross(Pb - Pa, Pc - Pa));
-                    if (Vector3.Dot(faceNormal, loopNormal) < 0)
+                    if (faceNormal.Z < 0)
                         faceNormal = -faceNormal;
 
                     AddPlanarVertex(vertices, Pa, loop[tri.X], faceNormal, uAxis, vAxis, plane[tri.X], minU, rangeU, minV, rangeV);
                     AddPlanarVertex(vertices, Pb, loop[tri.Y], faceNormal, uAxis, vAxis, plane[tri.Y], minU, rangeU, minV, rangeV);
                     AddPlanarVertex(vertices, Pc, loop[tri.Z], faceNormal, uAxis, vAxis, plane[tri.Z], minU, rangeU, minV, rangeV);
 
-                    // Reversed winding for TiXL's back-face culling (same convention as DelaunayMesh)
-                    triangles.Add(new Int3(firstVertex, firstVertex + 2, firstVertex + 1));
+                    // Flat fills face the default camera at (0, 0, +DefaultCameraDistance):
+                    // normal attribute and winding agree and both point toward +Z
+                    triangles.Add(new Int3(firstVertex, firstVertex + 1, firstVertex + 2));
                     firstVertex += 3;
                 }
             }

--- a/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.cs
+++ b/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.cs
@@ -1,0 +1,380 @@
+using SharpDX.Direct3D11;
+using T3.Core.Rendering;
+using Utilities = T3.Core.Utils.Utilities;
+
+namespace Lib.mesh.generate;
+
+[Guid("4E5AC2B9-5905-4F24-B0FC-0980357927D4")]
+internal sealed class ClosedLoopMesh : Instance<ClosedLoopMesh>
+{
+    [Output(Guid = "87125559-AF11-409E-B61A-D4DEA84202BA")]
+    public readonly Slot<MeshBuffers> Mesh = new();
+
+    public ClosedLoopMesh()
+    {
+        Mesh.UpdateAction += Update;
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        try
+        {
+            var pointBuffer = Points.GetValue(context);
+            var pointsPerShape = Math.Max(0, PointsPerShape.GetValue(context));
+
+            if (pointBuffer == null || pointBuffer.Buffer == null || pointBuffer.Buffer.Description.SizeInBytes == 0)
+            {
+                Log.Warning("ClosedLoopMesh: No points connected");
+                return;
+            }
+
+            if (pointBuffer.Buffer.Description.StructureByteStride != Point.Stride)
+            {
+                Log.Warning("ClosedLoopMesh: Buffer is not a Point-buffer (expected stride 64 bytes)");
+                return;
+            }
+
+            var points = ReadBackPoints(pointBuffer);
+            if (points.Length == 0)
+            {
+                Log.Warning("ClosedLoopMesh: No points could be read back");
+                return;
+            }
+
+            var loops = new List<Point[]>();
+            if (pointsPerShape > 0)
+            {
+                for (var start = 0; start < points.Length; start += pointsPerShape)
+                    CollectLoops(points, start, Math.Min(start + pointsPerShape, points.Length), loops);
+            }
+            else
+            {
+                CollectLoops(points, 0, points.Length, loops);
+            }
+
+            var vertices = new List<PbrVertex>();
+            var triangles = new List<Int3>();
+
+            foreach (var loop in loops)
+            {
+                if (loop.Length < 3)
+                    continue;
+
+                var positions = new Vector3[loop.Length];
+                for (var i = 0; i < loop.Length; i++)
+                    positions[i] = loop[i].Position;
+
+                var loopNormal = ComputeNewellNormal(positions);
+                if (loopNormal.LengthSquared() < 0.0001f)
+                {
+                    Log.Warning("ClosedLoopMesh: Degenerate loop - points are collinear");
+                    continue;
+                }
+
+                // Right-handed orthonormal basis (u x v = normal)
+                var uAxis = Vector3.Normalize(Vector3.Cross(PickMostOrthogonalAxis(loopNormal), loopNormal));
+                var vAxis = Vector3.Cross(loopNormal, uAxis);
+
+                var origin = positions[0];
+                var plane = new Vector2[loop.Length];
+                var minU = float.MaxValue;
+                var maxU = float.MinValue;
+                var minV = float.MaxValue;
+                var maxV = float.MinValue;
+                for (var i = 0; i < loop.Length; i++)
+                {
+                    var delta = positions[i] - origin;
+                    var u = Vector3.Dot(delta, uAxis);
+                    var v = Vector3.Dot(delta, vAxis);
+                    plane[i] = new Vector2(u, v);
+                    minU = MathF.Min(minU, u);
+                    maxU = MathF.Max(maxU, u);
+                    minV = MathF.Min(minV, v);
+                    maxV = MathF.Max(maxV, v);
+                }
+
+                if (!TryEarClip(plane, out var clipped))
+                {
+                    Log.Warning("ClosedLoopMesh: Loop triangulation failed (degenerate or self-intersecting polygon)");
+                    continue;
+                }
+
+                var rangeU = MathF.Max(maxU - minU, 0.0001f);
+                var rangeV = MathF.Max(maxV - minV, 0.0001f);
+
+                var firstVertex = vertices.Count;
+                foreach (var tri in clipped)
+                {
+                    Vector3 Pa = positions[tri.X];
+                    Vector3 Pb = positions[tri.Y];
+                    Vector3 Pc = positions[tri.Z];
+
+                    var faceNormal = Vector3.Normalize(Vector3.Cross(Pb - Pa, Pc - Pa));
+                    if (Vector3.Dot(faceNormal, loopNormal) < 0)
+                        faceNormal = -faceNormal;
+
+                    AddPlanarVertex(vertices, Pa, loop[tri.X], faceNormal, uAxis, vAxis, plane[tri.X], minU, rangeU, minV, rangeV);
+                    AddPlanarVertex(vertices, Pb, loop[tri.Y], faceNormal, uAxis, vAxis, plane[tri.Y], minU, rangeU, minV, rangeV);
+                    AddPlanarVertex(vertices, Pc, loop[tri.Z], faceNormal, uAxis, vAxis, plane[tri.Z], minU, rangeU, minV, rangeV);
+
+                    // Reversed winding for TiXL's back-face culling (same convention as DelaunayMesh)
+                    triangles.Add(new Int3(firstVertex, firstVertex + 2, firstVertex + 1));
+                    firstVertex += 3;
+                }
+            }
+
+            if (triangles.Count == 0 || vertices.Count == 0)
+            {
+                Log.Warning("ClosedLoopMesh: No valid loops to triangulate");
+                return;
+            }
+
+            UploadBuffers(vertices, triangles);
+        }
+        catch (Exception e)
+        {
+            Log.Error("ClosedLoopMesh: " + e.Message, this);
+        }
+    }
+
+    private static void AddPlanarVertex(List<PbrVertex> vertices, Vector3 position, Point point, Vector3 normal, Vector3 uAxis, Vector3 vAxis, Vector2 plane, float minU, float rangeU, float minV, float rangeV)
+    {
+        vertices.Add(new PbrVertex
+                         {
+                             Position = position,
+                             Normal = normal,
+                             Tangent = uAxis,
+                             Bitangent = vAxis,
+                             Texcoord = new Vector2((plane.X - minU) / rangeU, (plane.Y - minV) / rangeV),
+                             Selection = point.F1,
+                             ColorRgb = new Vector3(point.Color.X, point.Color.Y, point.Color.Z),
+                         });
+    }
+
+    private void UploadBuffers(List<PbrVertex> vertices, List<Int3> triangles)
+    {
+        var vertexCount = vertices.Count;
+        if (_vertexBufferData.Length != vertexCount)
+            _vertexBufferData = new PbrVertex[vertexCount];
+        vertices.CopyTo(_vertexBufferData);
+
+        var faceCount = triangles.Count;
+        if (_indexBufferData.Length != faceCount)
+            _indexBufferData = new Int3[faceCount];
+        triangles.CopyTo(_indexBufferData);
+
+        var stride = PbrVertex.Stride;
+        ResourceManager.SetupStructuredBuffer(_vertexBufferData, stride * vertexCount, stride, ref _vertexBuffer);
+        ResourceManager.CreateStructuredBufferSrv(_vertexBuffer, ref _vertexBufferWithViews.Srv);
+        ResourceManager.CreateStructuredBufferUav(_vertexBuffer, UnorderedAccessViewBufferFlags.None, ref _vertexBufferWithViews.Uav);
+        _vertexBufferWithViews.Buffer = _vertexBuffer;
+
+        stride = 3 * sizeof(int);
+        ResourceManager.SetupStructuredBuffer(_indexBufferData, stride * faceCount, stride, ref _indexBuffer);
+        ResourceManager.CreateStructuredBufferSrv(_indexBuffer, ref _indexBufferWithViews.Srv);
+        ResourceManager.CreateStructuredBufferUav(_indexBuffer, UnorderedAccessViewBufferFlags.None, ref _indexBufferWithViews.Uav);
+        _indexBufferWithViews.Buffer = _indexBuffer;
+
+        _data.VertexBuffer = _vertexBufferWithViews;
+        _data.IndicesBuffer = _indexBufferWithViews;
+        Mesh.Value = _data;
+        Mesh.DirtyFlag.Clear();
+    }
+
+    private Point[] ReadBackPoints(BufferWithViews pointBuffer)
+    {
+        var d3DDevice = ResourceManager.Device;
+        var immediateContext = d3DDevice.ImmediateContext;
+        var sourceBuffer = pointBuffer.Buffer;
+
+        if (_stagingBuffer == null
+            || _stagingBuffer.Buffer == null
+            || _stagingBuffer.Buffer.Description.SizeInBytes != sourceBuffer.Description.SizeInBytes
+            || _stagingBuffer.Buffer.Description.StructureByteStride != sourceBuffer.Description.StructureByteStride)
+        {
+            if (_stagingBuffer?.Buffer != null)
+                Utilities.Dispose(ref _stagingBuffer.Buffer);
+
+            _stagingBuffer ??= new BufferWithViews();
+
+            if (_stagingBuffer.Buffer == null
+                || _stagingBuffer.Buffer.Description.SizeInBytes != sourceBuffer.Description.SizeInBytes)
+            {
+                if (_stagingBuffer.Buffer != null)
+                    _stagingBuffer.Buffer.Dispose();
+
+                var bufferDesc = new BufferDescription
+                                     {
+                                         Usage = ResourceUsage.Default,
+                                         BindFlags = BindFlags.UnorderedAccess | BindFlags.ShaderResource,
+                                         SizeInBytes = sourceBuffer.Description.SizeInBytes,
+                                         OptionFlags = ResourceOptionFlags.BufferStructured,
+                                         StructureByteStride = sourceBuffer.Description.StructureByteStride,
+                                         CpuAccessFlags = CpuAccessFlags.Read,
+                                     };
+                _stagingBuffer.Buffer = new Buffer(ResourceManager.Device, bufferDesc);
+            }
+        }
+
+        immediateContext.CopyResource(sourceBuffer, _stagingBuffer.Buffer);
+        immediateContext.MapSubresource(_stagingBuffer.Buffer, 0, MapMode.Read, MapFlags.None, out var sourceStream);
+
+        Point[] points;
+        using (sourceStream)
+        {
+            var elementCount = sourceBuffer.Description.SizeInBytes / sourceBuffer.Description.StructureByteStride;
+            points = elementCount > 0 ? sourceStream.ReadRange<Point>(elementCount) : Array.Empty<Point>();
+        }
+
+        immediateContext.UnmapSubresource(_stagingBuffer.Buffer, 0);
+        return points;
+    }
+
+    private static void CollectLoops(Point[] points, int start, int end, List<Point[]> loops)
+    {
+        var current = new List<Point>();
+        for (var i = start; i < end; i++)
+        {
+            if (Point.IsSeparator(in points[i]))
+            {
+                if (current.Count > 0)
+                {
+                    loops.Add(current.ToArray());
+                    current = new List<Point>();
+                }
+            }
+            else
+            {
+                current.Add(points[i]);
+            }
+        }
+
+        if (current.Count > 0)
+            loops.Add(current.ToArray());
+    }
+
+    private static Vector3 PickMostOrthogonalAxis(Vector3 normal)
+    {
+        var absX = MathF.Abs(normal.X);
+        var absY = MathF.Abs(normal.Y);
+        var absZ = MathF.Abs(normal.Z);
+        return absX <= absY && absX <= absZ ? Vector3.UnitX
+            : absY <= absZ ? Vector3.UnitY
+            : Vector3.UnitZ;
+    }
+
+    private static Vector3 ComputeNewellNormal(Vector3[] positions)
+    {
+        var normal = Vector3.Zero;
+        for (var i = 0; i < positions.Length; i++)
+        {
+            var a = positions[i];
+            var b = positions[(i + 1) % positions.Length];
+            normal.X += (a.Y - b.Y) * (a.Z + b.Z);
+            normal.Y += (a.Z - b.Z) * (a.X + b.X);
+            normal.Z += (a.X - b.X) * (a.Y + b.Y);
+        }
+
+        var length = normal.Length();
+        return length > 0.0001f ? normal / length : Vector3.Zero;
+    }
+
+    private static bool TryEarClip(Vector2[] polygon, out List<Int3> triangles)
+    {
+        triangles = new List<Int3>();
+        if (polygon.Length < 3)
+            return false;
+
+        // Signed area: positive winding uses positive cross product for ears
+        var area = 0.0;
+        for (var i = 0; i < polygon.Length; i++)
+        {
+            var a = polygon[i];
+            var b = polygon[(i + 1) % polygon.Length];
+            area += a.X * (double)b.Y - b.X * (double)a.Y;
+        }
+        var counterClockwise = area > 0;
+
+        var remaining = new List<int>(polygon.Length);
+        for (var i = 0; i < polygon.Length; i++)
+            remaining.Add(i);
+
+        while (remaining.Count > 2)
+        {
+            var earFound = false;
+            var n = remaining.Count;
+            for (var i = 0; i < n; i++)
+            {
+                var aIndex = remaining[(i + n - 1) % n];
+                var bIndex = remaining[i];
+                var cIndex = remaining[(i + 1) % n];
+
+                var cross = Cross(polygon[aIndex], polygon[bIndex], polygon[cIndex]);
+                if (counterClockwise ? cross <= 0 : cross >= 0)
+                    continue;
+
+                var hasPointInside = false;
+                for (var j = 0; j < n; j++)
+                {
+                    var index = remaining[j];
+                    if (index == aIndex || index == bIndex || index == cIndex)
+                        continue;
+
+                    if (PointInTriangle(polygon[index], polygon[aIndex], polygon[bIndex], polygon[cIndex]))
+                    {
+                        hasPointInside = true;
+                        break;
+                    }
+                }
+
+                if (hasPointInside)
+                    continue;
+
+                triangles.Add(new Int3(aIndex, bIndex, cIndex));
+                remaining.RemoveAt(i);
+                earFound = true;
+                break;
+            }
+
+            if (!earFound)
+                return false;
+        }
+
+        return triangles.Count > 0;
+    }
+
+    private static float Cross(Vector2 a, Vector2 b, Vector2 c)
+    {
+        return (b.X - a.X) * (c.Y - a.Y) - (b.Y - a.Y) * (c.X - a.X);
+    }
+
+    private static bool PointInTriangle(Vector2 p, Vector2 a, Vector2 b, Vector2 c)
+    {
+        var d1 = Sign(p, a, b);
+        var d2 = Sign(p, b, c);
+        var d3 = Sign(p, c, a);
+        var hasNegative = d1 < 0 || d2 < 0 || d3 < 0;
+        var hasPositive = d1 > 0 || d2 > 0 || d3 > 0;
+        return !(hasNegative && hasPositive);
+    }
+
+    private static float Sign(Vector2 p1, Vector2 p2, Vector2 p3)
+    {
+        return (p1.X - p3.X) * (p2.Y - p3.Y) - (p2.X - p3.X) * (p1.Y - p3.Y);
+    }
+
+    private PbrVertex[] _vertexBufferData = Array.Empty<PbrVertex>();
+    private Int3[] _indexBufferData = Array.Empty<Int3>();
+    private Buffer _vertexBuffer;
+    private Buffer _indexBuffer;
+    private readonly BufferWithViews _vertexBufferWithViews = new();
+    private readonly BufferWithViews _indexBufferWithViews = new();
+    private readonly MeshBuffers _data = new();
+    private BufferWithViews _stagingBuffer;
+
+    [Input(Guid = "CCCAC1C9-926A-466A-B252-0D0E279102AE")]
+    public readonly InputSlot<BufferWithViews> Points = new();
+
+    [Input(Guid = "0F0D10D0-3EB0-4E12-8C06-E9DB4C000917")]
+    public readonly InputSlot<int> PointsPerShape = new();
+}

--- a/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.t3
+++ b/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.t3
@@ -1,0 +1,16 @@
+{
+  "FormatVersion": 3,
+  "Id": "4E5AC2B9-5905-4F24-B0FC-0980357927D4"/*ClosedLoopMesh*/,
+  "Inputs": [
+    {
+      "Id": "CCCAC1C9-926A-466A-B252-0D0E279102AE"/*Points*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "0F0D10D0-3EB0-4E12-8C06-E9DB4C000917"/*PointsPerShape*/,
+      "DefaultValue": 0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.t3ui
+++ b/Operators/Lib/Symbols/mesh/generate/ClosedLoopMesh.t3ui
@@ -1,0 +1,34 @@
+{
+  "FormatVersion": 3,
+  "Id": "4E5AC2B9-5905-4F24-B0FC-0980357927D4"/*ClosedLoopMesh*/,
+  "Description": "Turns closed point loops into a flat, filled triangle mesh. The counterpart to the fill step of an After Effects style shape repeater.\n\n- Consumes the same point buffer as [DrawClosedLines] (GPoints + PointsPerShape)\n- PointsPerShape = 0 wraps the whole buffer into one loop, otherwise the buffer is split into chunks of that size; separator points split loops within a chunk\n- Each loop is triangulated in its own plane (ear clipping), so concave shapes (stars, arrows, ...) fill correctly\n- Outputs a flat-shaded MeshBuffers: planar UVs, per-face normals, per-vertex ColorRgb and Selection (= source Point.F1, use it to address individual repeated shapes)\n\nRender the result with [DrawMesh] or combine with [ExtrudeCurves], [CombineMeshes], ...",
+  "SymbolTags": "1",
+  "InputUis": [
+    {
+      "InputId": "CCCAC1C9-926A-466A-B252-0D0E279102AE"/*Points*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Description": "Point buffer containing one or more closed loops (e.g. the output of [RepeatShapePoints])"
+    },
+    {
+      "InputId": "0F0D10D0-3EB0-4E12-8C06-E9DB4C000917"/*PointsPerShape*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 45.0
+      },
+      "Description": "Points per closed loop; 0 wraps the entire buffer into a single loop"
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "87125559-AF11-409E-B61A-D4DEA84202BA"/*Mesh*/,
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0
+      }
+    }
+  ]
+}

--- a/Operators/Lib/Symbols/point/generate/RepeatShapePoints.cs
+++ b/Operators/Lib/Symbols/point/generate/RepeatShapePoints.cs
@@ -1,0 +1,121 @@
+using SharpDX.Direct3D11;
+
+namespace Lib.point.generate;
+
+[Guid("BE4931F8-9816-48E5-A0A2-6AE8BC2DD390")]
+internal sealed class RepeatShapePoints : Instance<RepeatShapePoints>
+{
+    [Output(Guid = "64248B6B-C738-4D02-850C-9765CD0616D8")]
+    public readonly Slot<BufferWithViews> Points = new();
+
+    [Output(Guid = "B559D2B6-9A76-47C6-A0C6-2BB159B4C5FD")]
+    public readonly Slot<int> ShapeSize = new();
+
+    public RepeatShapePoints()
+    {
+        Points.UpdateAction += Update;
+    }
+
+    private void Update(EvaluationContext context)
+    {
+        var shape = Shape.GetValue(context);
+        var count = Math.Max(1, Count.GetValue(context));
+        var offsetPerCopy = OffsetPerCopy.GetValue(context);
+        var rotatePerCopy = RotatePerCopy.GetValue(context);
+        var scalePerCopy = ScalePerCopy.GetValue(context);
+
+        if (shape == null || shape.NumElements == 0)
+        {
+            Log.Warning("RepeatShapePoints: No shape points connected");
+            return;
+        }
+
+        if (shape is not StructuredList<Point> typedShape)
+        {
+            Log.Error("RepeatShapePoints: Shape is not a StructuredList<Point>");
+            return;
+        }
+
+        var shapePoints = new List<Point>(typedShape.NumElements);
+        foreach (var p in typedShape.TypedElements)
+        {
+            if (!Point.IsSeparator(in p))
+                shapePoints.Add(p);
+        }
+
+        var shapePointCount = shapePoints.Count;
+        if (shapePointCount < 3)
+        {
+            Log.Warning("RepeatShapePoints: Shape needs at least 3 usable points");
+            return;
+        }
+
+        ShapeSize.Value = shapePointCount;
+
+        // The rotation pivot and repeat reference point of the base shape
+        var centroid = Vector3.Zero;
+        foreach (var p in shapePoints)
+            centroid += p.Position;
+        centroid /= shapePointCount;
+
+        var rotation = new Vector3(
+            rotatePerCopy.X * MathF.PI / 180f,
+            rotatePerCopy.Y * MathF.PI / 180f,
+            rotatePerCopy.Z * MathF.PI / 180f);
+
+        var totalPointCount = shapePointCount * count;
+        if (_points.Length != totalPointCount)
+            _points = new Point[totalPointCount];
+
+        var writeIndex = 0;
+        for (var copyIndex = 0; copyIndex < count; copyIndex++)
+        {
+            var scale = 1f + scalePerCopy * copyIndex;
+            var copyQuaternion = Quaternion.CreateFromYawPitchRoll(
+                rotation.Y * copyIndex,
+                rotation.X * copyIndex,
+                rotation.Z * copyIndex);
+            var copyOffset = offsetPerCopy * copyIndex;
+
+            for (var pointIndex = 0; pointIndex < shapePointCount; pointIndex++)
+            {
+                var delta = shapePoints[pointIndex].Position - centroid;
+                var point = shapePoints[pointIndex];
+                point.Position = Vector3.Transform(delta * scale, copyQuaternion) + centroid + copyOffset;
+                point.F1 = copyIndex;
+                point.Orientation = Quaternion.Normalize(copyQuaternion * point.Orientation);
+                _points[writeIndex++] = point;
+            }
+        }
+
+        ResourceManager.SetupStructuredBuffer(_points, Point.Stride * totalPointCount, Point.Stride, ref _gpuBuffer);
+        ResourceManager.CreateStructuredBufferSrv(_gpuBuffer, ref _srv);
+        ResourceManager.CreateStructuredBufferUav(_gpuBuffer, UnorderedAccessViewBufferFlags.None, ref _uav);
+
+        _bufferWithViews.Buffer = _gpuBuffer;
+        _bufferWithViews.Srv = _srv;
+        _bufferWithViews.Uav = _uav;
+        Points.Value = _bufferWithViews;
+    }
+
+    private Point[] _points = Array.Empty<Point>();
+    private Buffer _gpuBuffer;
+    private ShaderResourceView _srv;
+    private UnorderedAccessView _uav;
+    private readonly BufferWithViews _bufferWithViews = new();
+
+    [Input(Guid = "A1AC028E-ADB7-46FC-814C-66551773AFBC")]
+    public readonly InputSlot<int> Count = new();
+
+    [Input(Guid = "6FAA2E91-082F-4656-8997-CEF767A7FBF2")]
+    public readonly InputSlot<Vector3> OffsetPerCopy = new();
+
+    [Input(Guid = "2E5DA9D4-0E82-4A93-84F8-BEE94DF58EBA")]
+    public readonly InputSlot<Vector3> RotatePerCopy = new();
+
+    [Input(Guid = "CD071504-AC40-4D03-9740-136B1C8AAE19")]
+    public readonly InputSlot<float> ScalePerCopy = new();
+
+    [Input(Guid = "3CA75113-5CD1-4FF5-8C4C-B8B22D60020D")]
+    public readonly InputSlot<StructuredList> Shape = new();
+}

--- a/Operators/Lib/Symbols/point/generate/RepeatShapePoints.t3
+++ b/Operators/Lib/Symbols/point/generate/RepeatShapePoints.t3
@@ -1,0 +1,36 @@
+{
+  "FormatVersion": 3,
+  "Id": "BE4931F8-9816-48E5-A0A2-6AE8BC2DD390"/*RepeatShapePoints*/,
+  "Inputs": [
+    {
+      "Id": "3CA75113-5CD1-4FF5-8C4C-B8B22D60020D"/*Shape*/,
+      "DefaultValue": null
+    },
+    {
+      "Id": "A1AC028E-ADB7-46FC-814C-66551773AFBC"/*Count*/,
+      "DefaultValue": 2
+    },
+    {
+      "Id": "6FAA2E91-082F-4656-8997-CEF767A7FBF2"/*OffsetPerCopy*/,
+      "DefaultValue": {
+        "X": 1.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    },
+    {
+      "Id": "2E5DA9D4-0E82-4A93-84F8-BEE94DF58EBA"/*RotatePerCopy*/,
+      "DefaultValue": {
+        "X": 0.0,
+        "Y": 0.0,
+        "Z": 0.0
+      }
+    },
+    {
+      "Id": "CD071504-AC40-4D03-9740-136B1C8AAE19"/*ScalePerCopy*/,
+      "DefaultValue": 0.0
+    }
+  ],
+  "Children": [],
+  "Connections": []
+}

--- a/Operators/Lib/Symbols/point/generate/RepeatShapePoints.t3ui
+++ b/Operators/Lib/Symbols/point/generate/RepeatShapePoints.t3ui
@@ -1,0 +1,66 @@
+{
+  "FormatVersion": 3,
+  "Id": "BE4931F8-9816-48E5-A0A2-6AE8BC2DD390"/*RepeatShapePoints*/,
+  "Description": "Repeats a closed shape point loop Count times, like an After Effects shape repeater.\n\nEach copy is transformed by its index:\n- OffsetPerCopy: how far to move each consecutive copy (a Vector3 -> can point along any axis)\n- RotatePerCopy: rotation increment around the shape centroid (degrees)\n- ScalePerCopy: linear scale increment per copy\n\nAll vertices of a copy share Point.F1 = copy index, so downstream operators (AddNoise, MapPointAttributes, CustomPointShader, ...) can manipulate the points of a single repeated shape.\n\nThe output buffer is laid out for [DrawClosedLines] with PointsPerShape set to the count of its shape points.\n\nConnect the ShapeSize output to the PointsPerShape input of [DrawClosedLines] and [ClosedLoopMesh] so every repeated copy is drawn and filled as its own separate closed shape.",
+  "SymbolTags": "1",
+  "InputUis": [
+    {
+      "InputId": "A1AC028E-ADB7-46FC-814C-66551773AFBC"/*Count*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 0.0
+      },
+      "Description": "Number of shape copies"
+    },
+    {
+      "InputId": "6FAA2E91-082F-4656-8997-CEF767A7FBF2"/*OffsetPerCopy*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 45.0
+      },
+      "Description": "Translation offset per copy - a Vector3, so it can point along any axis"
+    },
+    {
+      "InputId": "2E5DA9D4-0E82-4A93-84F8-BEE94DF58EBA"/*RotatePerCopy*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 90.0
+      },
+      "Description": "Rotation increment per copy around the shape centroid (degrees)"
+    },
+    {
+      "InputId": "CD071504-AC40-4D03-9740-136B1C8AAE19"/*ScalePerCopy*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 135.0
+      },
+      "Description": "Linear scale increment per copy (1 + index * ScalePerCopy)"
+    },
+    {
+      "InputId": "3CA75113-5CD1-4FF5-8C4C-B8B22D60020D"/*Shape*/,
+      "Position": {
+        "X": -200.0,
+        "Y": 180.0
+      },
+      "Description": "Closed loop of points describing the base shape (separators are skipped)"
+    }
+  ],
+  "SymbolChildUis": [],
+  "OutputUis": [
+    {
+      "OutputId": "B559D2B6-9A76-47C6-A0C6-2BB159B4C5FD"/*ShapeSize*/,
+      "Position": {
+        "X": 160.0,
+        "Y": 45.0
+      },
+      "Description": "Points per repeated shape - connect to PointsPerShape of [DrawClosedLines] / [ClosedLoopMesh]"
+    },
+    {
+      "OutputId": "64248B6B-C738-4D02-850C-9765CD0616D8"/*Points*/,
+      "Position": {
+        "X": 0.0,
+        "Y": 0.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds two new operators for After Effects style shape repetition:

- **[RepeatShapePoints]**: repeats a closed shape point loop Count times. Each copy is transformed by its index (OffsetPerCopy / RotatePerCopy / ScalePerCopy, rotation around the shape centroid). All vertices of a copy share Point.F1 = copy index so downstream ops can address individual repeated shapes. Outputs a Point buffer laid out for [DrawClosedLines] plus a ShapeSize output for PointsPerShape wiring.

It works with open shapes too but open shapes become a single connected shape with the repetitions in between the repeater start and end 

- **[ClosedLoopMesh]**: turns closed point loops into a flat, filled triangle mesh via per-plane ear clipping, with planar UVs, per-face normals, ColorRgb and Selection (= source Point.F1). Consumes the same Point buffer / PointsPerShape as [DrawClosedLines].
 

https://github.com/user-attachments/assets/4fd01836-f820-4492-b8fb-79632d223c07

